### PR TITLE
Handle unclean repos

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -24,5 +24,5 @@ jobs:
       - name: bazel test //...
         env:
           # Bazelisk will download bazel to here, ensure it is cached between runs.
-          XDG_CACHE_HOME: ~/.cache/bazel-repo
+          XDG_CACHE_HOME: /home/runner/.cache/bazel-repo
         run: bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,10 +5,10 @@ http_archive(
     patch_args = ["-p1"],
     # Pull in https://github.com/bazelbuild/bazel-gazelle/pull/1227
     patches = ["@//:third_party/patches/bazel_gazelle/1227-label-pattern-matching.patch"],
-    sha256 = "b751f7fa79829a06778e91cb721e2bcd1e7251d9b22eb8d9ebc4993ecb3ef8dc",
-    strip_prefix = "bazel-gazelle-bd319f810c16ba206a2b87422e8d328cefaded88",
+    sha256 = "dae13a7c6adb742174aafd340ebcb36016de231bd4f926f79c140c7d9b599fb0",
+    strip_prefix = "bazel-gazelle-757e291d1befe9174fb1fcf0d9ade733cbb6b904",
     urls = [
-        "https://github.com/bazelbuild/bazel-gazelle/archive/bd319f810c16ba206a2b87422e8d328cefaded88.zip",
+        "https://github.com/bazelbuild/bazel-gazelle/archive/757e291d1befe9174fb1fcf0d9ade733cbb6b904.zip",
     ],
 )
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -132,10 +132,16 @@ func ResolveCommonConfig(commonFlags *CommonFlags, beforeRevStr string) (*Common
 		return nil, fmt.Errorf("failed to resolve the \"after\" (i.e. original) git revision: %w", err)
 	}
 
+	outputBase, err := pkg.BazelOutputBase(*commonFlags.BazelPath, workingDirectory)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve the bazel output base: %w", err)
+	}
+
 	context := &pkg.Context{
 		WorkspacePath:    workingDirectory,
 		OriginalRevision: afterRev,
 		BazelPath:        *commonFlags.BazelPath,
+		BazelOutputBase:  outputBase,
 		IgnoredFiles:     *commonFlags.IgnoredFiles,
 	}
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -59,7 +59,6 @@ func RegisterCommonFlags() *CommonFlags {
 type ProcessedCommonArgs struct {
 	Context        *pkg.Context
 	RevisionBefore pkg.LabelledGitRev
-	RevisionAfter  pkg.LabelledGitRev
 	TargetPattern  gazelle_label.Pattern
 }
 
@@ -79,10 +78,10 @@ func ProcessCommonArgs(commonFlags *CommonFlags, targetPatternFlag *string) (*Pr
 	}
 
 	context := &pkg.Context{
-		OriginalWorkspacePath: workingDirectory,
-		OriginalRevision:      afterRev,
-		BazelPath:             *commonFlags.BazelPath,
-		IgnoredFiles:          *commonFlags.IgnoredFiles,
+		WorkspacePath:    workingDirectory,
+		OriginalRevision: afterRev,
+		BazelPath:        *commonFlags.BazelPath,
+		IgnoredFiles:     *commonFlags.IgnoredFiles,
 	}
 
 	positional := flag.Args()
@@ -102,7 +101,6 @@ func ProcessCommonArgs(commonFlags *CommonFlags, targetPatternFlag *string) (*Pr
 	return &ProcessedCommonArgs{
 		Context:        context,
 		RevisionBefore: beforeRev,
-		RevisionAfter:  afterRev,
 		TargetPattern:  targetPattern,
 	}, nil
 }

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -26,7 +26,6 @@ import (
 
 type config struct {
 	RevisionBefore pkg.LabelledGitRev
-	RevisionAfter  pkg.LabelledGitRev
 	Context        *pkg.Context
 	// One of "run" or "skip".
 	ManualTestMode string
@@ -62,7 +61,6 @@ func main() {
 
 	if err := pkg.WalkAffectedTargets(config.Context,
 		config.RevisionBefore,
-		config.RevisionAfter,
 		config.TargetPattern,
 		false,
 		callback); err != nil {
@@ -97,7 +95,7 @@ func main() {
 
 	log.Printf("Running %s on %d targets", commandVerb, len(targets))
 	cmd := exec.Command(config.Context.BazelPath, commandVerb, "--target_pattern_file", targetPatternFile.Name())
-	cmd.Dir = config.Context.OriginalWorkspacePath
+	cmd.Dir = config.Context.WorkspacePath
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -136,7 +134,6 @@ func parseFlags() (*config, error) {
 
 	return &config{
 		RevisionBefore: commonArgs.RevisionBefore,
-		RevisionAfter:  commonArgs.RevisionAfter,
 		Context:        commonArgs.Context,
 		ManualTestMode: *manualTestMode,
 		TargetPattern:  commonArgs.TargetPattern,

--- a/pkg/walker.go
+++ b/pkg/walker.go
@@ -14,8 +14,8 @@ type WalkCallback func(label.Label, []Difference, *analysis.ConfiguredTarget)
 // callback once for each target which has changed.
 // Explanation of the differences may be expensive in both time and memory to compute, so if
 // includeDifferences is set to false, the []Difference parameter to the callback will always be nil.
-func WalkAffectedTargets(context *Context, commitishBefore, commitishAfter LabelledGitRev, pattern label.Pattern, includeDifferences bool, callback WalkCallback) error {
-	beforeMetadata, afterMetadata, err := FullyProcess(context, commitishBefore, commitishAfter, pattern)
+func WalkAffectedTargets(context *Context, revBefore LabelledGitRev, pattern label.Pattern, includeDifferences bool, callback WalkCallback) error {
+	beforeMetadata, afterMetadata, err := FullyProcess(context, revBefore, pattern)
 	if err != nil {
 		return fmt.Errorf("failed to process change: %w", err)
 	}

--- a/target-determinator/target-determinator.go
+++ b/target-determinator/target-determinator.go
@@ -60,7 +60,6 @@ func main() {
 
 	if err := pkg.WalkAffectedTargets(config.Context,
 		config.RevisionBefore,
-		config.RevisionAfter,
 		config.TargetPattern,
 		config.Verbose,
 		callback); err != nil {
@@ -84,7 +83,6 @@ func parseFlags() (*config, error) {
 
 	return &config{
 		RevisionBefore: commonArgs.RevisionBefore,
-		RevisionAfter:  commonArgs.RevisionAfter,
 		Context:        commonArgs.Context,
 		Verbose:        *verbose,
 		TargetPattern:  commonArgs.TargetPattern,

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDiffIntegrationTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDiffIntegrationTest.java
@@ -103,19 +103,6 @@ public class BazelDiffIntegrationTest extends Tests {
   // Different behaviour with respect to errors
 
   @Override
-  public void failForUncleanRepository() {
-    try {
-      Files.createFile(testDir.resolve("untracked-file"));
-    } catch (IOException e) {
-      fail(e.getMessage());
-    }
-    expectFailure();
-
-    // bazel-diff does not return any targets on failure.
-    doTest(Commits.TWO_TESTS, Commits.EXPLICIT_DEFAULT_VALUE, Set.of("//java/example:ExampleTest"));
-  }
-
-  @Override
   public void reducingVisibilityOnDependencyAffectsTarget() {
     expectFailure();
     doTest(
@@ -137,7 +124,7 @@ public class BazelDiffIntegrationTest extends Tests {
 
   @Override
   @Ignore
-  public void failForUncleanSubmodule() {}
+  public void succeedForUncleanSubmodule() {}
 
   // Misc
 

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDiffIntegrationTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDiffIntegrationTest.java
@@ -1,10 +1,7 @@
 package com.github.bazel_contrib.target_determinator.integration;
 
-import static junit.framework.TestCase.fail;
-
 import com.github.bazel_contrib.target_determinator.label.Label;
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableSet;
 import java.io.File;
 import java.io.IOException;
 import java.lang.ProcessBuilder.Redirect;
@@ -67,7 +64,7 @@ public class BazelDiffIntegrationTest extends Tests {
       if (processBuilder.start().waitFor() != 0) {
         throw new TargetComputationErrorException(
             String.format("Expected exit code 0 when running %s", Joiner.on(" ").join(argv)),
-            ImmutableSet.of());
+            "");
       }
     } catch (IOException | InterruptedException e) {
       throw new RuntimeException(e);
@@ -100,18 +97,6 @@ public class BazelDiffIntegrationTest extends Tests {
   @Ignore("bazel-diff doesn't inspect configurations.")
   public void changingHostConfigurationDoesNotAffectTargetConfiguration() {}
 
-  // Different behaviour with respect to errors
-
-  @Override
-  public void reducingVisibilityOnDependencyAffectsTarget() {
-    expectFailure();
-    doTest(
-        Commits.ADD_INDIRECTION_FOR_SIMPLE_JAVA_LIBRARY,
-        Commits.REDUCE_DEPENDENCY_VISIBILITY,
-        // bazel-diff doesn't return any targets on failure.
-        Set.of());
-  }
-
   // Submodules
 
   @Override
@@ -133,13 +118,13 @@ public class BazelDiffIntegrationTest extends Tests {
   public void testRelativeRevisions() {}
 
   @Override
-  public void explicitlySpecifyingDefaultValueDoesNotTrigger_native() {
+  public void explicitlySpecifyingDefaultValueDoesNotTrigger_native() throws Exception {
     allowOverBuilds("bazel-diff isn't aware of attribute defaults.");
     super.explicitlySpecifyingDefaultValueDoesNotTrigger_native();
   }
 
   @Override
-  public void refactoringStarlarkRuleIsNoOp() {
+  public void refactoringStarlarkRuleIsNoOp() throws Exception {
     allowOverBuilds(
         "Rule implementation attr factors in hashes of entire transitively loaded bzl files, rather"
             + " than anything more granular or processed");

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDifferIntegrationTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDifferIntegrationTest.java
@@ -132,19 +132,6 @@ public class BazelDifferIntegrationTest extends Tests {
   // Different behaviour with respect to errors
 
   @Override
-  public void failForUncleanRepository() {
-    try {
-      Files.createFile(testDir.resolve("untracked-file"));
-    } catch (IOException e) {
-      fail(e.getMessage());
-    }
-    expectFailure();
-
-    // bazel-differ does not return any targets on failure.
-    doTest(Commits.TWO_TESTS, Commits.EXPLICIT_DEFAULT_VALUE, Set.of("//java/example:ExampleTest"));
-  }
-
-  @Override
   public void reducingVisibilityOnDependencyAffectsTarget() {
     expectFailure();
     doTest(
@@ -158,6 +145,10 @@ public class BazelDifferIntegrationTest extends Tests {
 
   @Override
   @Ignore
+  public void addTrivialSubmodule() {}
+
+  @Override
+  @Ignore
   public void changeSubmodulePath() {}
 
   @Override
@@ -166,7 +157,7 @@ public class BazelDifferIntegrationTest extends Tests {
 
   @Override
   @Ignore
-  public void failForUncleanSubmodule() {}
+  public void succeedForUncleanSubmodule() {}
 
   // Misc
 

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDifferIntegrationTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDifferIntegrationTest.java
@@ -1,10 +1,7 @@
 package com.github.bazel_contrib.target_determinator.integration;
 
-import static junit.framework.TestCase.fail;
-
 import com.github.bazel_contrib.target_determinator.label.Label;
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableSet;
 import java.io.File;
 import java.io.IOException;
 import java.lang.ProcessBuilder.Redirect;
@@ -60,7 +57,7 @@ public class BazelDifferIntegrationTest extends Tests {
       if (processBuilder.start().waitFor() != 0) {
         throw new TargetComputationErrorException(
             String.format("Expected exit code 0 when running %s", Joiner.on(" ").join(argv)),
-            ImmutableSet.of());
+            "");
       }
     } catch (IOException | InterruptedException e) {
       throw new RuntimeException(e);
@@ -96,25 +93,25 @@ public class BazelDifferIntegrationTest extends Tests {
   // Returning things in //external
 
   @Override
-  public void unconsumedIndirectWorkspaceChangeIsNoOp() {
+  public void unconsumedIndirectWorkspaceChangeIsNoOp() throws Exception {
     allowOverBuilds("bazel-differ returns targets in //external as changed");
     super.unconsumedIndirectWorkspaceChangeIsNoOp();
   }
 
   @Override
-  public void movingStarlarkRuleToExternalRepoIsNoOp() {
+  public void movingStarlarkRuleToExternalRepoIsNoOp() throws Exception {
     allowOverBuilds("bazel-differ returns targets in //external as changed");
     super.movingStarlarkRuleToExternalRepoIsNoOp();
   }
 
   @Override
-  public void modifyingRuleViaWorkspaceFile() {
+  public void modifyingRuleViaWorkspaceFile() throws Exception {
     allowOverBuilds("bazel-differ returns targets in //external as changed");
     super.modifyingRuleViaWorkspaceFile();
   }
 
   @Override
-  public void changingFileLoadedByWorkspaceTriggersTargets() {
+  public void changingFileLoadedByWorkspaceTriggersTargets() throws Exception {
     allowOverBuilds("bazel-differ returns targets in //external as changed");
     super.changingFileLoadedByWorkspaceTriggersTargets();
   }
@@ -128,18 +125,6 @@ public class BazelDifferIntegrationTest extends Tests {
   @Override
   @Ignore("bazel-differ doesn't seem to track bazel versions.")
   public void changedBazelVersion_starlark() {}
-
-  // Different behaviour with respect to errors
-
-  @Override
-  public void reducingVisibilityOnDependencyAffectsTarget() {
-    expectFailure();
-    doTest(
-        Commits.ADD_INDIRECTION_FOR_SIMPLE_JAVA_LIBRARY,
-        Commits.REDUCE_DEPENDENCY_VISIBILITY,
-        // bazel-differ doesn't return any targets on failure.
-        Set.of());
-  }
 
   // Submodules
 
@@ -166,13 +151,13 @@ public class BazelDifferIntegrationTest extends Tests {
   public void testRelativeRevisions() {}
 
   @Override
-  public void explicitlySpecifyingDefaultValueDoesNotTrigger_native() {
+  public void explicitlySpecifyingDefaultValueDoesNotTrigger_native() throws Exception {
     allowOverBuilds("bazel-differ isn't aware of attribute defaults.");
     super.explicitlySpecifyingDefaultValueDoesNotTrigger_native();
   }
 
   @Override
-  public void refactoringStarlarkRuleIsNoOp() {
+  public void refactoringStarlarkRuleIsNoOp() throws Exception {
     allowOverBuilds(
         "Rule implementation attr factors in hashes of entire transitively loaded bzl files, rather"
             + " than anything more granular or processed");

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetComputationErrorException.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetComputationErrorException.java
@@ -1,20 +1,19 @@
 package com.github.bazel_contrib.target_determinator.integration;
 
-import com.github.bazel_contrib.target_determinator.label.Label;
-import com.google.common.collect.ImmutableSet;
-
 /** TargetComputationErrorException represents an error when computing targets. */
 class TargetComputationErrorException extends Exception {
 
-  private final ImmutableSet<Label> targets;
+  private final String output;
 
-  /** getTargets returns any targets which were output to stdout. */
-  public ImmutableSet<Label> getTargets() {
-    return targets;
+  /**
+   * getOutput returns the stdout of the failed command.
+   */
+  public String getOutput() {
+    return output;
   }
 
-  public TargetComputationErrorException(String errorMessage, ImmutableSet<Label> targets) {
+  public TargetComputationErrorException(String errorMessage, String output) {
     super(errorMessage);
-    this.targets = targets;
+    this.output = output;
   }
 }

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminator.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminator.java
@@ -1,15 +1,18 @@
 package com.github.bazel_contrib.target_determinator.integration;
 
 import com.github.bazel_contrib.target_determinator.label.Label;
+import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
+import com.google.common.hash.Hashing;
 import com.google.common.io.ByteStreams;
 import java.io.File;
 import java.io.IOException;
 import java.lang.ProcessBuilder.Redirect;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Set;
 
 /** Wrapper around a target-determinator binary. */
@@ -21,6 +24,12 @@ public class TargetDeterminator {
   public static Set<Label> getTargets(Path workspace, String... argv)
       throws TargetComputationErrorException {
     return runProcess(workspace, TARGET_DETERMINATOR, argv);
+  }
+
+  public static Path getWorktreePath(Path workingDirectory) {
+    Path cacheDir = Paths.get(System.getProperty("user.home"), ".cache", "target-determinator");
+    String workingDirHash = Hashing.sha1().hashString(workingDirectory.toString(), Charsets.UTF_8).toString();
+    return cacheDir.resolve(String.format("td-worktree-%s-%s", workingDirectory.getFileName(), workingDirHash));
   }
 
   private static ImmutableSet<Label> runProcess(Path workingDirectory, String argv0, String... argv)

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorIntegrationTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorIntegrationTest.java
@@ -22,6 +22,7 @@ public class TargetDeterminatorIntegrationTest extends Tests {
         "bazelisk",
         "--ignore-file",
         ignoredDirectoryName,
+        "--delete-cached-worktree",
         commitBefore);
   }
 

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
@@ -3,12 +3,19 @@ package com.github.bazel_contrib.target_determinator.integration;
 import com.github.bazel_contrib.target_determinator.label.Label;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.eclipse.jgit.util.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import static junit.framework.TestCase.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TargetDeterminatorSpecificFlagsTest {
   private static TestdataRepo testdataRepo;
@@ -34,8 +41,9 @@ public class TargetDeterminatorSpecificFlagsTest {
 
   @Test
   public void targetPatternFlagAll() throws Exception {
+    TestdataRepo.gitCheckout(testDir, Commits.BAZELRC_TEST_ENV);
     Set<Label> targets =
-        getTargets(Commits.TWO_LANGUAGES_OF_TESTS, Commits.BAZELRC_TEST_ENV, "//...");
+        getTargets(Commits.TWO_LANGUAGES_OF_TESTS, "//...");
     Util.assertTargetsMatch(
         targets,
         Set.of("//java/example:ExampleTest", "//java/example:OtherExampleTest", "//sh:sh_test"),
@@ -45,8 +53,8 @@ public class TargetDeterminatorSpecificFlagsTest {
 
   @Test
   public void targetPatternFlagJava() throws Exception {
-    Set<Label> targets =
-        getTargets(Commits.TWO_LANGUAGES_OF_TESTS, Commits.BAZELRC_TEST_ENV, "//java/...");
+    TestdataRepo.gitCheckout(testDir, Commits.BAZELRC_TEST_ENV);
+    Set<Label> targets = getTargets(Commits.TWO_LANGUAGES_OF_TESTS, "//java/...");
     Util.assertTargetsMatch(
         targets,
         Set.of("//java/example:ExampleTest", "//java/example:OtherExampleTest"),
@@ -56,31 +64,84 @@ public class TargetDeterminatorSpecificFlagsTest {
 
   @Test
   public void targetPatternFlagOneTarget() throws Exception {
-    Set<Label> targets =
-        getTargets(
-            Commits.TWO_LANGUAGES_OF_TESTS, Commits.BAZELRC_TEST_ENV, "//java/example:ExampleTest");
+    TestdataRepo.gitCheckout(testDir, Commits.BAZELRC_TEST_ENV);
+    Set<Label> targets = getTargets(Commits.TWO_LANGUAGES_OF_TESTS, "//java/example:ExampleTest");
     Util.assertTargetsMatch(targets, Set.of("//java/example:ExampleTest"), Set.of(), false);
   }
 
   @Test
   public void targetPatternFlagOneTargetNotAffected() throws Exception {
+    TestdataRepo.gitCheckout(testDir, Commits.TWO_TESTS);
     Set<Label> targets =
         getTargets(
-            Commits.TWO_NATIVE_TESTS_BAZEL3, Commits.TWO_TESTS, "//java/example:ExampleTest");
+            Commits.TWO_NATIVE_TESTS_BAZEL3, "//java/example:ExampleTest");
     Util.assertTargetsMatch(targets, Set.of("//java/example:ExampleTest"), Set.of(), false);
   }
 
-  private Set<Label> getTargets(String commitBefore, String commitAfter, String targetPattern)
+  @Test
+  public void failForUncleanRepositoryWithEnforceClean() throws Exception {
+    TestdataRepo.gitCheckout(testDir, Commits.HAS_JVM_FLAGS);
+
+    Files.createFile(testDir.resolve("untracked-file"));
+
+    Set<Label> targets = null;
+    try {
+      getTargets(Commits.TWO_TESTS, "//...", true);
+    } catch (TargetComputationErrorException e) {
+      targets = e.getTargets();
+    }
+    // If `targets` is not set at this point in the code, it means the command succeeded.
+    if (targets == null) {
+      fail("Expected target-determinator command to fail but it succeeded");
+    }
+    Util.assertTargetsMatch(targets, Set.of("//..."), Set.of(), false);
+  }
+
+  @Test
+  public void succeedForUncleanIgnoredFilesWithEnforceClean() throws Exception {
+    TestdataRepo.gitCheckout(testDir, Commits.TWO_TESTS_WITH_GITIGNORE);
+
+    Path ignoredFile = testDir.resolve("ignored-file");
+    Files.createFile(ignoredFile);
+
+    Set<Label> targets = getTargets(Commits.ONE_TEST, "//...", true);
+    Util.assertTargetsMatch(targets, Set.of("//java/example:OtherExampleTest"), Set.of(), false);
+
+    assertThat("expected ignored file to still be present after invocation", ignoredFile.toFile().exists());
+  }
+
+  @Test
+  public void failForUncleanSubmoduleWithEnforceClean() throws Exception {
+    TestdataRepo.gitCheckout(testDir, Commits.SUBMODULE_CHANGE_DIRECTORY);
+
+    Files.createFile(testDir.resolve("demo-submodule-2").resolve("untracked-file"));
+
+    Set<Label> targets = null;
+    try {
+      getTargets(Commits.SUBMODULE_ADD_DEPENDENT_ON_SIMPLE_JAVA_LIBRARY,
+          "//...", true);
+    } catch (TargetComputationErrorException e) {
+      targets = e.getTargets();
+    }
+    // If `targets` is not set at this point in the code, it means the command succeeded.
+    if (targets == null) {
+      fail("Expected target-determinator command to fail but it succeeded");
+    }
+    Util.assertTargetsMatch(targets, Set.of("//..."), Set.of(), false);
+  }
+
+  private Set<Label> getTargets(String commitBefore, String targetPattern) throws Exception {
+    return getTargets(commitBefore, targetPattern, false);
+  }
+
+  private Set<Label> getTargets(String commitBefore, String targetPattern, boolean enforceClean)
       throws Exception {
-    TestdataRepo.gitCheckout(testDir, commitAfter);
-    return TargetDeterminator.getTargets(
-        testDir,
-        "--working-directory",
-        testDir.toString(),
-        "--bazel",
-        "bazelisk",
-        "--target-pattern",
-        targetPattern,
-        commitBefore);
+    final List<String> args = Stream.of("--working-directory", testDir.toString(), "--bazel", "bazelisk",
+            "--target-pattern", targetPattern).collect(Collectors.toList());
+    if (enforceClean) {
+      args.add("--enforce-clean=enforce-clean");
+    }
+    args.add(commitBefore);
+    return TargetDeterminator.getTargets(testDir, args.toArray(new String[0]));
   }
 }

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.jgit.util.FileUtils;
+import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -84,17 +85,12 @@ public class TargetDeterminatorSpecificFlagsTest {
 
     Files.createFile(testDir.resolve("untracked-file"));
 
-    Set<Label> targets = null;
     try {
       getTargets(Commits.TWO_TESTS, "//...", true);
-    } catch (TargetComputationErrorException e) {
-      targets = e.getTargets();
-    }
-    // If `targets` is not set at this point in the code, it means the command succeeded.
-    if (targets == null) {
       fail("Expected target-determinator command to fail but it succeeded");
+    } catch (TargetComputationErrorException e) {
+      assertThat(e.getOutput(), CoreMatchers.equalTo("Target Determinator invocation Error\n"));
     }
-    Util.assertTargetsMatch(targets, Set.of("//..."), Set.of(), false);
   }
 
   @Test
@@ -116,18 +112,13 @@ public class TargetDeterminatorSpecificFlagsTest {
 
     Files.createFile(testDir.resolve("demo-submodule-2").resolve("untracked-file"));
 
-    Set<Label> targets = null;
     try {
       getTargets(Commits.SUBMODULE_ADD_DEPENDENT_ON_SIMPLE_JAVA_LIBRARY,
           "//...", true);
-    } catch (TargetComputationErrorException e) {
-      targets = e.getTargets();
-    }
-    // If `targets` is not set at this point in the code, it means the command succeeded.
-    if (targets == null) {
       fail("Expected target-determinator command to fail but it succeeded");
+    } catch (TargetComputationErrorException e) {
+      assertThat(e.getOutput(), CoreMatchers.equalTo("Target Determinator invocation Error\n"));
     }
-    Util.assertTargetsMatch(targets, Set.of("//..."), Set.of(), false);
   }
 
   private Set<Label> getTargets(String commitBefore, String targetPattern) throws Exception {

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
@@ -353,11 +353,10 @@ public abstract class Tests {
   }
 
   @Test
-  public void failForUncleanRepository() throws IOException {
+  public void succeedForUncleanRepository() throws IOException {
     Files.createFile(testDir.resolve("untracked-file"));
 
-    expectFailure();
-    doTest(Commits.TWO_TESTS, Commits.EXPLICIT_DEFAULT_VALUE, Set.of("//..."));
+    doTest(Commits.TWO_TESTS, Commits.HAS_JVM_FLAGS, Set.of("//java/example:ExampleTest"));
   }
 
   @Test
@@ -375,16 +374,14 @@ public abstract class Tests {
   }
 
   @Test
-  public void failForUncleanSubmodule() throws Exception {
+  public void succeedForUncleanSubmodule() throws Exception {
     gitCheckout(Commits.SUBMODULE_CHANGE_DIRECTORY);
 
     Files.createFile(testDir.resolve("demo-submodule-2").resolve("untracked-file"));
 
-    expectFailure();
-    doTest(
-        Commits.SUBMODULE_ADD_DEPENDENT_ON_SIMPLE_JAVA_LIBRARY,
-        Commits.SUBMODULE_CHANGE_DIRECTORY,
-        Set.of("//..."));
+    doTest(Commits.SUBMODULE_ADD_DEPENDENT_ON_SIMPLE_JAVA_LIBRARY,
+            Commits.SUBMODULE_CHANGE_DIRECTORY,
+            Set.of("//demo-submodule-2:submodule_simple"));
   }
 
   @Test

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
@@ -6,7 +6,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 
 import com.github.bazel_contrib.target_determinator.label.Label;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
@@ -50,7 +49,6 @@ public abstract class Tests {
   protected static final String ignoredFileName = "some-file";
 
   private boolean allowOverBuilds = false;
-  private boolean expectFailure = false;
 
   @Rule public TestName name = new TestName();
 
@@ -61,10 +59,6 @@ public abstract class Tests {
 
   protected void allowOverBuilds(String reason) {
     this.allowOverBuilds = true;
-  }
-
-  protected void expectFailure() {
-    this.expectFailure = true;
   }
 
   protected boolean supportsIgnoredUnaddedFiles() {
@@ -95,28 +89,28 @@ public abstract class Tests {
   }
 
   @Test
-  public void addedTarget_native() {
+  public void addedTarget_native() throws Exception {
     doTest(Commits.ONE_TEST, Commits.TWO_TESTS, Set.of("//java/example:OtherExampleTest"));
   }
 
   @Test
-  public void deletedTarget_native() {
+  public void deletedTarget_native() throws Exception {
     doTest(
         Commits.TWO_TESTS, Commits.ONE_TEST, Set.of(), Set.of("//java/example:OtherExampleTest"));
   }
 
   @Test
-  public void ruleAffectingAttributeChange_native() {
+  public void ruleAffectingAttributeChange_native() throws Exception {
     doTest(Commits.TWO_TESTS, Commits.HAS_JVM_FLAGS, Set.of("//java/example:ExampleTest"));
   }
 
   @Test
-  public void explicitlySpecifyingDefaultValueDoesNotTrigger_native() {
+  public void explicitlySpecifyingDefaultValueDoesNotTrigger_native() throws Exception {
     doTest(Commits.TWO_TESTS, Commits.EXPLICIT_DEFAULT_VALUE, Set.of());
   }
 
   @Test
-  public void changedBazelVersion_native() {
+  public void changedBazelVersion_native() throws Exception {
     doTest(
         Commits.TWO_TESTS,
         Commits.TWO_NATIVE_TESTS_BAZEL3,
@@ -124,7 +118,7 @@ public abstract class Tests {
   }
 
   @Test
-  public void changedBazelVersion_starlark() {
+  public void changedBazelVersion_starlark() throws Exception {
     doTest(
         Commits.SIMPLE_JAVA_LIBRARY_TARGETS,
         Commits.SIMPLE_TARGETS_BAZEL3,
@@ -132,12 +126,12 @@ public abstract class Tests {
   }
 
   @Test
-  public void changedSrc() {
+  public void changedSrc() throws Exception {
     doTest(Commits.TWO_TESTS, Commits.MODIFIED_TEST_SRC, Set.of("//java/example:ExampleTest"));
   }
 
   @Test
-  public void changedTransitiveSrc() {
+  public void changedTransitiveSrc() throws Exception {
     doTest(
         Commits.SIMPLE_JAVA_LIBRARY_TARGETS,
         Commits.CHANGE_TRANSITIVE_FILE,
@@ -145,7 +139,7 @@ public abstract class Tests {
   }
 
   @Test
-  public void changedBazelrcAffectingAllTests() {
+  public void changedBazelrcAffectingAllTests() throws Exception {
     doTest(
         Commits.TWO_LANGUAGES_OF_TESTS,
         Commits.BAZELRC_TEST_ENV,
@@ -153,7 +147,7 @@ public abstract class Tests {
   }
 
   @Test
-  public void changedBazelrcAffectingSomeTests() {
+  public void changedBazelrcAffectingSomeTests() throws Exception {
     doTest(
         Commits.TWO_LANGUAGES_OF_TESTS,
         Commits.BAZELRC_AFFECTING_JAVA,
@@ -161,12 +155,12 @@ public abstract class Tests {
   }
 
   @Test
-  public void emptyTryImportInBazelrc() {
+  public void emptyTryImportInBazelrc() throws Exception {
     doTest(Commits.TWO_TESTS, Commits.ADD_OPTIONAL_PRESENT_EMPTY_BAZELRC, Set.of());
   }
 
   @Test
-  public void tryImportInBazelrcAffectingJava() {
+  public void tryImportInBazelrcAffectingJava() throws Exception {
     doTest(
         Commits.TWO_LANGUAGES_OF_TESTS,
         Commits.TWO_LANGUAGES_OPTIONAL_MISSING_TRY_IMPORT,
@@ -186,12 +180,12 @@ public abstract class Tests {
   }
 
   @Test
-  public void importInBazelrcNotAffectingJava() {
+  public void importInBazelrcNotAffectingJava() throws Exception {
     doTest(Commits.TWO_LANGUAGES_OF_TESTS, Commits.TWO_LANGUAGES_NOOP_IMPORTED_BAZELRC, Set.of());
   }
 
   @Test
-  public void importInBazelrcAffectingJava() {
+  public void importInBazelrcAffectingJava() throws Exception {
     doTest(
         Commits.TWO_LANGUAGES_OF_TESTS,
         Commits.TWO_LANGUAGES_IMPORTED_BAZELRC_AFFECTING_JAVA,
@@ -199,12 +193,12 @@ public abstract class Tests {
   }
 
   @Test
-  public void addedUnusedStarlarkRulesTriggersNoTargets() {
+  public void addedUnusedStarlarkRulesTriggersNoTargets() throws Exception {
     doTest(Commits.TWO_TESTS, Commits.JAVA_TESTS_AND_SIMPLE_JAVA_RULES, Set.of());
   }
 
   @Test
-  public void starlarkRulesTrigger() {
+  public void starlarkRulesTrigger() throws Exception {
     doTest(
         Commits.SIMPLE_JAVA_LIBRARY_RULE,
         Commits.SIMPLE_JAVA_LIBRARY_TARGETS,
@@ -212,7 +206,7 @@ public abstract class Tests {
   }
 
   @Test
-  public void addingDepOnStarlarkRulesTrigger() {
+  public void addingDepOnStarlarkRulesTrigger() throws Exception {
     doTest(
         Commits.SIMPLE_JAVA_LIBRARY_AND_JAVA_TESTS,
         Commits.DEP_ON_STARLARK_TARGET,
@@ -220,7 +214,7 @@ public abstract class Tests {
   }
 
   @Test
-  public void changingStarlarkRuleDefinition() {
+  public void changingStarlarkRuleDefinition() throws Exception {
     doTest(
         Commits.DEP_ON_STARLARK_TARGET,
         Commits.CHANGE_STARLARK_RULE_IMPLEMENTATION,
@@ -231,7 +225,7 @@ public abstract class Tests {
   }
 
   @Test
-  public void refactoringStarlarkRuleIsNoOp() {
+  public void refactoringStarlarkRuleIsNoOp() throws Exception {
     doTest(
         Commits.CHANGE_STARLARK_RULE_IMPLEMENTATION,
         Commits.NOOP_REFACTOR_STARLARK_RULE_IMPLEMENTATION,
@@ -239,7 +233,7 @@ public abstract class Tests {
   }
 
   @Test
-  public void movingStarlarkRuleToExternalRepoIsNoOp() {
+  public void movingStarlarkRuleToExternalRepoIsNoOp() throws Exception {
     doTest(
         Commits.NOOP_REFACTOR_STARLARK_RULE_IMPLEMENTATION,
         Commits.RULES_IN_EXTERNAL_REPO,
@@ -247,12 +241,12 @@ public abstract class Tests {
   }
 
   @Test
-  public void refactoringWorkspaceFileInNoOp() {
+  public void refactoringWorkspaceFileInNoOp() throws Exception {
     doTest(Commits.RULES_IN_EXTERNAL_REPO, Commits.NOOP_REFACTOR_IN_WORKSPACE_FILE, Set.of());
   }
 
   @Test
-  public void modifyingRuleViaWorkspaceFile() {
+  public void modifyingRuleViaWorkspaceFile() throws Exception {
     doTest(
         Commits.NOOP_REFACTOR_IN_WORKSPACE_FILE,
         Commits.ADD_SIMPLE_PACKAGE_RULE,
@@ -260,12 +254,12 @@ public abstract class Tests {
   }
 
   @Test
-  public void unconsumedIndirectWorkspaceChangeIsNoOp() {
+  public void unconsumedIndirectWorkspaceChangeIsNoOp() throws Exception {
     doTest(Commits.ADD_SIMPLE_PACKAGE_RULE, Commits.REFACTORED_WORKSPACE_INDIRECTLY, Set.of());
   }
 
   @Test
-  public void changingMacroExpansionBasedOnFileExistence() {
+  public void changingMacroExpansionBasedOnFileExistence() throws Exception {
     // Add a second target - changes the definition of the first target, so it should re-run:
     doTest(
         Commits.PATHOLOGICAL_RULES_SINGLE_TARGET,
@@ -290,7 +284,7 @@ public abstract class Tests {
   }
 
   @Test
-  public void changingFileLoadedByWorkspaceTriggersTargets() {
+  public void changingFileLoadedByWorkspaceTriggersTargets() throws Exception {
     doTest(
         Commits.ADD_SIMPLE_PACKAGE_RULE,
         Commits.CHANGE_ATTRIBUTES_VIA_INDIRECTION,
@@ -301,24 +295,24 @@ public abstract class Tests {
   }
 
   @Test
-  public void removingGlobbedFileTriggers() {
+  public void removingGlobbedFileTriggers() throws Exception {
     doTest(Commits.HAS_GLOBS, Commits.CHANGE_GLOBS, Set.of("//globs:root"));
   }
 
   @Test
-  public void removingBuildFileRetriggersGlobs() {
+  public void removingBuildFileRetriggersGlobs() throws Exception {
     doTest(
         Commits.ADD_BUILD_FILE_INTERFERING_WTH_GLOBS, Commits.CHANGE_GLOBS, Set.of("//globs:root"));
   }
 
   @Test
-  public void addingBuildFileRetriggersGlobs() {
+  public void addingBuildFileRetriggersGlobs() throws Exception {
     doTest(
         Commits.CHANGE_GLOBS, Commits.ADD_BUILD_FILE_INTERFERING_WTH_GLOBS, Set.of("//globs:root"));
   }
 
   @Test
-  public void addingTargetUsedInHostConfiguration() {
+  public void addingTargetUsedInHostConfiguration() throws Exception {
     doTest(
         Commits.BAZELRC_INCLUDED_EMPTY,
         Commits.JAVA_USED_IN_GENRULE,
@@ -326,7 +320,7 @@ public abstract class Tests {
   }
 
   @Test
-  public void changingHostConfigurationDoesNotAffectTargetConfiguration() {
+  public void changingHostConfigurationDoesNotAffectTargetConfiguration() throws Exception {
     // Only run_jbin should be present because it's the only host java target
     doTest(
         Commits.JAVA_USED_IN_GENRULE,
@@ -335,7 +329,7 @@ public abstract class Tests {
   }
 
   @Test
-  public void changingTargetConfigurationDoesNotAffectHostConfiguration() {
+  public void changingTargetConfigurationDoesNotAffectHostConfiguration() throws Exception {
     // run_jbin should not be present because it's configured in host not target
     doTest(
         Commits.JAVA_USED_IN_GENRULE,
@@ -344,23 +338,27 @@ public abstract class Tests {
   }
 
   @Test
-  public void reducingVisibilityOnDependencyAffectsTarget() {
-    expectFailure();
-    doTest(
-        Commits.ADD_INDIRECTION_FOR_SIMPLE_JAVA_LIBRARY,
-        Commits.REDUCE_DEPENDENCY_VISIBILITY,
-        Set.of("//..."));
+  public void reducingVisibilityOnDependencyAffectsTarget() throws Exception {
+    try {
+      doTest(
+          Commits.ADD_INDIRECTION_FOR_SIMPLE_JAVA_LIBRARY,
+          Commits.REDUCE_DEPENDENCY_VISIBILITY,
+          Set.of("//NotApplicable"));
+      fail("Expected target-determinator command to fail but it succeeded");
+    } catch (TargetComputationErrorException e) {
+      // Invocation failed as expected.
+    }
   }
 
   @Test
-  public void succeedForUncleanRepository() throws IOException {
+  public void succeedForUncleanRepository() throws Exception {
     Files.createFile(testDir.resolve("untracked-file"));
 
     doTest(Commits.TWO_TESTS, Commits.HAS_JVM_FLAGS, Set.of("//java/example:ExampleTest"));
   }
 
   @Test
-  public void succeedForUncleanIgnoredFiles() throws IOException {
+  public void succeedForUncleanIgnoredFiles() throws Exception {
     Path ignoredFile = testDir.resolve("ignored-file");
     Files.createFile(ignoredFile);
 
@@ -385,7 +383,7 @@ public abstract class Tests {
   }
 
   @Test
-  public void addTrivialSubmodule() {
+  public void addTrivialSubmodule() throws Exception {
     doTest(Commits.SIMPLE_JAVA_LIBRARY_TARGETS, Commits.SUBMODULE_ADD_TRIVIAL_SUBMODULE, Set.of());
     assertThat(
         "The submodule should now be present with its README.md but isn't",
@@ -393,7 +391,7 @@ public abstract class Tests {
   }
 
   @Test
-  public void addDependentTargetInSubmodule() {
+  public void addDependentTargetInSubmodule() throws Exception {
     doTest(
         Commits.SUBMODULE_ADD_TRIVIAL_SUBMODULE,
         Commits.SUBMODULE_ADD_DEPENDENT_ON_SIMPLE_JAVA_LIBRARY,
@@ -401,7 +399,7 @@ public abstract class Tests {
   }
 
   @Test
-  public void changeSubmodulePath() {
+  public void changeSubmodulePath() throws Exception {
     doTest(
         Commits.SUBMODULE_ADD_DEPENDENT_ON_SIMPLE_JAVA_LIBRARY,
         Commits.SUBMODULE_CHANGE_DIRECTORY,
@@ -417,7 +415,7 @@ public abstract class Tests {
   }
 
   @Test
-  public void deleteSubmodule() {
+  public void deleteSubmodule() throws Exception {
     doTest(Commits.SUBMODULE_CHANGE_DIRECTORY, Commits.SUBMODULE_DELETE_SUBMODULE, Set.of());
 
     assertThat(
@@ -442,7 +440,7 @@ public abstract class Tests {
         gitBranch());
   }
 
-  public void doTest(String commitBefore, String commitAfter, Set<String> expectedTargets) {
+  public void doTest(String commitBefore, String commitAfter, Set<String> expectedTargets) throws TargetComputationErrorException {
     doTest(commitBefore, commitAfter, expectedTargets, Set.of());
   }
 
@@ -450,7 +448,7 @@ public abstract class Tests {
       String commitBefore,
       String commitAfter,
       Set<String> expectedTargetStrings,
-      Set<String> forbiddenTargetStrings) {
+      Set<String> forbiddenTargetStrings) throws TargetComputationErrorException {
     // Check out the commitAfter as it is a requirement for target-determinator.
     try {
       gitCheckout(commitAfter);
@@ -458,22 +456,7 @@ public abstract class Tests {
       fail(e.getMessage());
     }
 
-    Set<Label> targets = null;
-    boolean succeeded = true;
-    try {
-      targets = getTargets(commitBefore, commitAfter);
-    } catch (TargetComputationErrorException e) {
-      if (expectFailure) {
-        targets = e.getTargets();
-      } else {
-        fail(e.getMessage());
-      }
-      succeeded = false;
-    }
-    if (succeeded && expectFailure) {
-        fail("Expected failure running command, but got zero exit status. Output: " + targets.toString());
-    }
-
+    Set<Label> targets = getTargets(commitBefore, commitAfter);
     Util.assertTargetsMatch(
         targets, expectedTargetStrings, forbiddenTargetStrings, allowOverBuilds);
 

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
@@ -459,6 +459,7 @@ public abstract class Tests {
     }
 
     Set<Label> targets = null;
+    boolean succeeded = true;
     try {
       targets = getTargets(commitBefore, commitAfter);
     } catch (TargetComputationErrorException e) {
@@ -467,6 +468,10 @@ public abstract class Tests {
       } else {
         fail(e.getMessage());
       }
+      succeeded = false;
+    }
+    if (succeeded && expectFailure) {
+        fail("Expected failure running command, but got zero exit status. Output: " + targets.toString());
     }
 
     Util.assertTargetsMatch(


### PR DESCRIPTION
Previously, target-determinator only worked on clean git repositories.

With this change, one can run it on an unclean repository, i.e. with untracked files (even non-ignored ones) and uncommitted changes. This is particularly useful for local development. The original behaviour can be useful on CI and can hence be preserved with the `--require-clean` enum option.

To ensure we leave it in a pristine state, we use a separate git worktree when the repository is unclean. This is slower than working directly on the original repository worktree so we include a couple of optimisations:
- To make the most of the original worktree's Bazel daemon's cache, we pass the original workspace's Bazel output base in the relevant invocations.
- To avoid checking out new worktrees again and again (which can be costly with large repositories), we cache the worktree locall. This can be disabled with the new 
- `--delete-cached-worktree` option.

A few minor improvements were introduced as well. This is best reviewed commit by commit.

❤️