### PR TITLE
Create release action

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -8,16 +8,16 @@ jobs:
   presubmit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Check dependencies and format
         run: scripts/update-dependencies && scripts/format && { [[ -z "$(git status --porcelain)" ]] || exit 1; }
       - name: Mount bazel action cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: "~/.cache/bazel"
           key: bazel
       - name: Mount bazel repo cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: "~/.cache/bazel-repo"
           key: bazel-repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: release
+on:
+  push:
+    tags:
+      - "*"
+permissions:
+  contents: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: build
+        run: mkdir .release-artifacts && cp $(bazel build --show_result=9999 target-determinator:all driver:all 2>&1 | grep 'bazel-out') .release-artifacts/
+      - name: release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: .release-artifacts/*
+          prerelease: true
+          generate_release_notes: true

--- a/driver/BUILD.bazel
+++ b/driver/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//rules:multi_platform_go_binary.bzl", "multi_platform_go_binary")
 
 go_library(
     name = "driver_lib",
@@ -13,7 +14,7 @@ go_library(
     ],
 )
 
-go_binary(
+multi_platform_go_binary(
     name = "driver",
     embed = [":driver_lib"],
     visibility = ["//visibility:public"],

--- a/rules/multi_platform_go_binary.bzl
+++ b/rules/multi_platform_go_binary.bzl
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+
+_PLATFORMS = [
+    ("darwin", "amd64"),
+    ("darwin", "arm64"),
+    ("linux", "amd64"),
+    ("linux", "arm64"),
+    ("windows", "amd64"),
+]
+
+def multi_platform_go_binary(name, **kwargs):
+    if "visibility" not in kwargs:
+        kwargs["visibility"] = "//visibility:public"
+
+    if "goos" in kwargs or "goarch" in kwargs:
+        fail("Can't specify goos or goarch for multi_platform_go_binary")
+
+    go_binary(
+        name = name,
+        **kwargs
+    )
+
+    for goos, goarch in _PLATFORMS:
+        go_binary(
+            name = "{}.{}.{}".format(name, goos, goarch),
+            goos = goos,
+            goarch = goarch,
+            **kwargs
+        )

--- a/target-determinator/BUILD.bazel
+++ b/target-determinator/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//rules:multi_platform_go_binary.bzl", "multi_platform_go_binary")
 
 go_library(
     name = "target-determinator_lib",
@@ -13,7 +14,7 @@ go_library(
     ],
 )
 
-go_binary(
+multi_platform_go_binary(
     name = "target-determinator",
     embed = [":target-determinator_lib"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Releases pre-built binaries of driver and target-determinator on:
{darwin,linux} x {amd64,arm64}
windows x amd64

As GitHub releases automatically for every pushed tag.