### PR TITLE
Don't output duplicate labels in non-verbose mode

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -56,6 +56,7 @@ func main() {
 	}
 
 	var targets []gazelle_label.Label
+	targetsSet := make(map[gazelle_label.Label]struct{})
 	commandVerb := "build"
 
 	log.Println("Discovering affected targets")
@@ -63,7 +64,11 @@ func main() {
 		if config.ManualTestMode == "skip" && isTaggedManual(configuredTarget) {
 			return
 		}
+		if _, seen := targetsSet[label]; seen {
+			return
+		}
 		targets = append(targets, label)
+		targetsSet[label] = struct{}{}
 		// This is not an ideal heuristic, ideally cquery would expose to us whether a target is a test target.
 		if strings.HasSuffix(configuredTarget.GetTarget().GetRule().GetRuleClass(), "_test") {
 			commandVerb = "test"

--- a/target-determinator/target-determinator.go
+++ b/target-determinator/target-determinator.go
@@ -56,7 +56,13 @@ func main() {
 		log.Fatalf("Error during preprocessing: %v", err)
 	}
 
+	seenLabels := make(map[gazelle_label.Label]struct{})
 	callback := func(label gazelle_label.Label, differences []pkg.Difference, configuredTarget *analysis.ConfiguredTarget) {
+		if !config.Verbose {
+			if _, seen := seenLabels[label]; seen {
+				return
+			}
+		}
 		fmt.Print(label)
 		if len(differences) > 0 {
 			fmt.Printf(" Changes:")
@@ -68,6 +74,7 @@ func main() {
 			}
 		}
 		fmt.Println("")
+		seenLabels[label] = struct{}{}
 	}
 
 	if err := pkg.WalkAffectedTargets(config.Context,


### PR DESCRIPTION
In verbose mode, we may output different configurations of labels with
different explanations.

In non-verbose mode, duplicates are not expected.