### PR TITLE
Create an interface for executing Bazel commands

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -137,7 +137,9 @@ func ResolveCommonConfig(commonFlags *CommonFlags, beforeRevStr string) (*Common
 		return nil, fmt.Errorf("failed to resolve the \"after\" (i.e. original) git revision: %w", err)
 	}
 
-	outputBase, err := pkg.BazelOutputBase(*commonFlags.BazelPath, workingDirectory)
+	bazelCmd := pkg.DefaultBazelCmd{BazelPath: *commonFlags.BazelPath}
+
+	outputBase, err := pkg.BazelOutputBase(workingDirectory, bazelCmd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve the bazel output base: %w", err)
 	}
@@ -145,7 +147,7 @@ func ResolveCommonConfig(commonFlags *CommonFlags, beforeRevStr string) (*Common
 	context := &pkg.Context{
 		WorkspacePath:        workingDirectory,
 		OriginalRevision:     afterRev,
-		BazelPath:            *commonFlags.BazelPath,
+		BazelCmd:             bazelCmd,
 		BazelOutputBase:      outputBase,
 		DeleteCachedWorktree: commonFlags.DeleteCachedWorktree,
 		IgnoredFiles:         *commonFlags.IgnoredFiles,

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -110,11 +109,11 @@ func main() {
 	}
 
 	log.Printf("Running %s on %d targets", commandVerb, len(targets))
-	cmd := exec.Command(config.Context.BazelPath, commandVerb, "--target_pattern_file", targetPatternFile.Name())
-	cmd.Dir = config.Context.WorkspacePath
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	result, err := config.Context.BazelCmd.Execute(
+		pkg.BazelCmdConfig{Dir: config.Context.WorkspacePath, Stdout: os.Stdout, Stderr: os.Stderr},
+		commandVerb, "--target_pattern_file", targetPatternFile.Name())
+
+	if result != 0 || err != nil {
 		log.Fatal(err)
 	}
 }

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "pkg",
     srcs = [
+        "bazel.go",
         "hash_cache.go",
         "target_determinator.go",
         "targets_list.go",

--- a/pkg/bazel.go
+++ b/pkg/bazel.go
@@ -1,0 +1,44 @@
+package pkg
+
+import (
+	"io"
+	"os/exec"
+)
+
+type BazelCmdConfig struct {
+	// Dir represents the working directory to use for the command.
+	// If Dir is the empty string, use the calling process's current directory.
+	Dir string
+
+	// Stdout and Stderr specify the process's standard output and error.
+	// A nil value redirects the output to /dev/null.
+	// The behavior is the same as the exec.Command struct.
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+type BazelCmd interface {
+	Execute(config BazelCmdConfig, args ...string) (int, error)
+}
+
+type DefaultBazelCmd struct {
+	BazelPath string
+}
+
+// Execute calls bazel with the provided arguments.
+// It returns the exit status code or -1 if it errored before the process could start.
+func (c DefaultBazelCmd) Execute(config BazelCmdConfig, args ...string) (int, error) {
+	cmd := exec.Command(c.BazelPath, args...)
+	cmd.Dir = config.Dir
+	cmd.Stdout = config.Stdout
+	cmd.Stderr = config.Stderr
+
+	if err := cmd.Run(); err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			return exitError.ExitCode(), err
+		} else {
+			return -1, err
+		}
+	}
+	return 0, nil
+}


### PR DESCRIPTION
This makes it easier to plug the Target Determinator into larger
applications that already have tight control over how Bazel is executed
(eg. when using this as a plugin of Aspect's CLI tool).