### PR TITLE
Hash file mode

### DIFF
--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
@@ -462,6 +462,11 @@ public abstract class Tests {
         gitBranch());
   }
 
+  @Test
+  public void testChmodFile() throws TargetComputationErrorException {
+    doTest(Commits.ONE_SH_TEST, Commits.SH_TEST_NOT_EXECUTABLE, Set.of("//sh:sh_test"));
+  }
+
   public void doTest(String commitBefore, String commitAfter, Set<String> expectedTargets) throws TargetComputationErrorException {
     doTest(commitBefore, commitAfter, expectedTargets, Set.of());
   }
@@ -578,4 +583,8 @@ class Commits {
       "dde94a13e0f6f9a970bcaf700c45fc4ecb4e7949";
   public static final String TWO_TESTS_BRANCH =
       "two-tests-branch"; // Local only (created by the test case).
+  public static final String ONE_SH_TEST = 
+      "106ac1dd1fd762c3786e1f01b2aa47fc1eccab99"; // (v0/sh-test) add an executable shell file and BUILD.bazel file
+  public static final String SH_TEST_NOT_EXECUTABLE = 
+      "845171a918115260b50fb487e93c82d49e62abf6"; // (v0/sh-test+1) make shell file non-executable
 }


### PR DESCRIPTION
Add the file mode to the hash. This should support invalidating hash on `chmod +x $filename` scenarios.

Refactored the `TestDigestTree` test into initial state + subtests instead of a long flat test.