### PR TITLE
Allow cli to be re-used outside of repo

### DIFF
--- a/cli/BUILD.bazel
+++ b/cli/BUILD.bazel
@@ -1,13 +1,10 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "cli_lib",
+    name = "cli",
     srcs = ["flags.go"],
     importpath = "github.com/bazel-contrib/target-determinator/cli",
-    visibility = [
-        "//driver:__subpackages__",
-        "//target-determinator:__subpackages__",
-    ],
+    visibility = ["//visibility:public"],
     deps = [
         "//common",
         "//pkg",

--- a/driver/BUILD.bazel
+++ b/driver/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
     importpath = "github.com/bazel-contrib/target-determinator/driver",
     visibility = ["//visibility:private"],
     deps = [
-        "//cli:cli_lib",
+        "//cli",
         "//pkg",
         "//third_party/protobuf/bazel/analysis",
         "@bazel_gazelle//label:go_default_library",

--- a/target-determinator/BUILD.bazel
+++ b/target-determinator/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
     importpath = "github.com/bazel-contrib/target-determinator/target-determinator",
     visibility = ["//visibility:private"],
     deps = [
-        "//cli:cli_lib",
+        "//cli",
         "//pkg",
         "//third_party/protobuf/bazel/analysis",
         "@bazel_gazelle//label:go_default_library",


### PR DESCRIPTION
We intend for people to be able to build their own wrappers around the
API in their own repo, and the cli wrapper is a useful abstraction for
this.