### PR TITLE
Handle invalid "before" queries

### DIFF
--- a/pkg/target_determinator.go
+++ b/pkg/target_determinator.go
@@ -115,7 +115,11 @@ func FullyProcess(context *Context, revBefore LabelledGitRev, revAfter LabelledG
 	log.Printf("Processing %s", revBefore)
 	queryInfoBefore, err := fullyProcessRevision(context, revBefore, targets)
 	if err != nil {
-		return nil, nil, err
+		if queryInfoBefore == nil {
+			return nil, nil, err
+		} else {
+			log.Printf("A query error occurred quering %s - ignoring the error and treating all matching targets from the '%s' revision as affected.", revBefore, revAfter.Label)
+		}
 	}
 
 	// At this point, we assume that the working directory is back to its pristine state.
@@ -128,6 +132,11 @@ func FullyProcess(context *Context, revBefore LabelledGitRev, revAfter LabelledG
 	return queryInfoBefore, queryInfoAfter, nil
 }
 
+// fullyProcessRevision may return a nil error and a non-nil queryInfo.
+// This indicates that evaluating the initial query at this revision failed,
+// but that the user may want to use the results anyway, despite their query results being empty.
+// This may be useful when the "before" commit is broken for query, as it allows for running all
+// matching targets from the "after" query, despite the "before" being broken.
 func fullyProcessRevision(context *Context, rev LabelledGitRev, targets TargetsList) (queryInfo *QueryResults, err error) {
 	defer func() {
 		innerErr := gitCheckout(context.WorkspacePath, context.OriginalRevision)
@@ -138,7 +147,7 @@ func fullyProcessRevision(context *Context, rev LabelledGitRev, targets TargetsL
 	queryInfo, loadMetadataCleanup, err := LoadIncompleteMetadata(context, rev, targets)
 	defer loadMetadataCleanup()
 	if err != nil {
-		return nil, fmt.Errorf("failed to load metadata at %s: %w", rev, err)
+		return queryInfo, fmt.Errorf("failed to load metadata at %s: %w", rev, err)
 	}
 
 	log.Println("Hashing targets")
@@ -155,6 +164,10 @@ func fullyProcessRevision(context *Context, rev LabelledGitRev, targets TargetsL
 // responsibility to check out the original commit.
 //
 // It returns a non-nil callback to clean up the worktree if it was created.
+//
+// Note that a non-nil QueryResults may be returned even in the error case, which will have an
+// empty target-set, but may contain other useful information (e.g. the bazel release version).
+// Checking for nil-ness of the error is the true arbiter for whether the entire load was successful.
 func LoadIncompleteMetadata(context *Context, rev LabelledGitRev, targets TargetsList) (*QueryResults, func(), error) {
 	// Create a temporary context to allow the workspace path to point to a git worktree if necessary.
 	context = &Context{
@@ -196,7 +209,7 @@ func LoadIncompleteMetadata(context *Context, rev LabelledGitRev, targets Target
 
 	queryInfo, err := doQueryDeps(context, targets)
 	if err != nil {
-		return nil, cleanupFunc, fmt.Errorf("failed to query at %s in %v: %w", rev, context.WorkspacePath, err)
+		return queryInfo, cleanupFunc, fmt.Errorf("failed to query at %s in %v: %w", rev, context.WorkspacePath, err)
 	}
 	return queryInfo, cleanupFunc, nil
 }
@@ -561,6 +574,9 @@ func bazelInfo(workingDirectory string, bazelCmd BazelCmd, key string) (string, 
 	return strings.TrimRight(stdoutBuf.String(), "\n"), nil
 }
 
+// Note that a non-nil QueryResults may be returned even in the error case, which will have an
+// empty target-set, but may contain other useful information (e.g. the bazel release version).
+// Checking for nil-ness of the error is the true arbiter for whether the entire query was successful.
 func doQueryDeps(context *Context, targets TargetsList) (*QueryResults, error) {
 	bazelRelease, err := BazelRelease(context.WorkspacePath, context.BazelCmd)
 	if err != nil {
@@ -570,7 +586,15 @@ func doQueryDeps(context *Context, targets TargetsList) (*QueryResults, error) {
 	depsPattern := fmt.Sprintf("deps(%s)", targets.String())
 	transitiveResult, err := runToCqueryResult(context, depsPattern)
 	if err != nil {
-		return nil, fmt.Errorf("failed to cquery %v: %w", depsPattern, err)
+		return &QueryResults{
+			MatchingTargets: &MatchingTargets{
+				labels:                 nil,
+				labelsToConfigurations: nil,
+			},
+			TransitiveConfiguredTargets: nil,
+			TargetHashCache:             NewTargetHashCache(nil, bazelRelease),
+			BazelRelease:                bazelRelease,
+		}, fmt.Errorf("failed to cquery %v: %w", depsPattern, err)
 	}
 
 	transitiveConfiguredTargets, err := ParseCqueryResult(transitiveResult)

--- a/pkg/walker.go
+++ b/pkg/walker.go
@@ -54,8 +54,12 @@ func DiffSingleLabel(beforeMetadata, afterMetadata *QueryResults, includeDiffere
 		}
 
 		if len(beforeMetadata.MatchingTargets.ConfigurationsFor(label)) == 0 {
+			category := "NewLabel"
+			if beforeMetadata.QueryError != nil {
+				category = "ErrorInQueryBefore"
+			}
 			collectDifference(Difference{
-				Category: "NewLabel",
+				Category: category,
 			})
 			callback(label, differences, configuredTarget)
 			return nil

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BUILD.bazel
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BUILD.bazel
@@ -84,6 +84,7 @@ java_test(
         "//tests/integration/java/com/github/bazel_contrib/target_determinator/label",
         artifact("junit:junit"),
         artifact("org.eclipse.jgit:org.eclipse.jgit"),
+        artifact("org.hamcrest:hamcrest-all"),
     ],
 )
 

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDifferIntegrationTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDifferIntegrationTest.java
@@ -175,4 +175,8 @@ public class BazelDifferIntegrationTest extends Tests {
   @Override
   @Ignore("bazel-differ doesn't check file modes")
   public void testChmodFile() {}
+
+  @Override
+  @Ignore("bazel-differ doesn't handle no targets being returned from a query")
+  public void zeroToOneTarget_native() {}
 }

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
@@ -80,6 +80,13 @@ public class TargetDeterminatorSpecificFlagsTest {
   }
 
   @Test
+  public void targetPatternFlagQueryBeforeWasError() throws Exception {
+    TestdataRepo.gitCheckout(testDir, Commits.ONE_TEST);
+    Set<Label> targets = getTargets(Commits.NO_TARGETS, "//java/...");
+    Util.assertTargetsMatch(targets, Set.of("//java/example:ExampleTest"), Set.of(), false);
+  }
+
+  @Test
   public void failForUncleanRepositoryWithEnforceClean() throws Exception {
     TestdataRepo.gitCheckout(testDir, Commits.HAS_JVM_FLAGS);
 

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
@@ -3,6 +3,7 @@ package com.github.bazel_contrib.target_determinator.integration;
 import com.github.bazel_contrib.target_determinator.label.Label;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -17,6 +18,7 @@ import org.junit.Test;
 
 import static junit.framework.TestCase.fail;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 
 public class TargetDeterminatorSpecificFlagsTest {
   private static TestdataRepo testdataRepo;
@@ -87,6 +89,16 @@ public class TargetDeterminatorSpecificFlagsTest {
   }
 
   @Test
+  public void targetPatternFlagQueryBeforeWasErrorVerbose() throws Exception {
+    TestdataRepo.gitCheckout(testDir, Commits.ONE_TEST);
+    String output = getOutput(Commits.NO_TARGETS, "//java/...", false, true, List.of("--verbose"));
+    // This isn't great output, and we shouldn't worry about changing its format in the future,
+    // but this test is to ensure we return a result indicating "the query before was bad" rather
+    // than "this target didn't exist before".
+    assertThat(output, equalTo("//java/example:ExampleTest Changes: ErrorInQueryBefore\n"));
+  }
+
+  @Test
   public void failForUncleanRepositoryWithEnforceClean() throws Exception {
     TestdataRepo.gitCheckout(testDir, Commits.HAS_JVM_FLAGS);
 
@@ -151,11 +163,23 @@ public class TargetDeterminatorSpecificFlagsTest {
 
   private Set<Label> getTargets(String commitBefore, String targets, boolean enforceClean, boolean deleteCachedWorktree)
       throws Exception {
-    final List<String> args = Stream.of("--working-directory",
-        testDir.toString(),
-        "--bazel", "bazelisk",
-        "--targets", targets 
-        ).collect(Collectors.toList());
+    return getTargets(commitBefore, targets, enforceClean, deleteCachedWorktree, new ArrayList<>());
+  }
+
+  private Set<Label> getTargets(String commitBefore, String targets, boolean enforceClean, boolean deleteCachedWorktree, List<String> flags)
+      throws Exception {
+    return TargetDeterminator.parseLabels(getOutput(commitBefore, targets, enforceClean, deleteCachedWorktree, flags));
+  }
+
+  private String getOutput(String commitBefore, String targets, boolean enforceClean, boolean deleteCachedWorktree, List<String> flags) throws Exception {
+    final List<String> args = Stream.concat(
+        Stream.of("--working-directory",
+            testDir.toString(),
+            "--bazel", "bazelisk",
+            "--targets", targets
+        ),
+        flags.stream()
+    ).collect(Collectors.toList());
     if (enforceClean) {
       args.add("--enforce-clean=enforce-clean");
     }
@@ -163,6 +187,6 @@ public class TargetDeterminatorSpecificFlagsTest {
       args.add("--delete-cached-worktree");
     }
     args.add(commitBefore);
-    return TargetDeterminator.getTargets(testDir, args.toArray(new String[0]));
+    return TargetDeterminator.getOutput(testDir, args.toArray(new String[0]));
   }
 }

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
@@ -89,6 +89,11 @@ public abstract class Tests {
   }
 
   @Test
+  public void zeroToOneTarget_native() throws Exception {
+    doTest(Commits.NO_TARGETS, Commits.ONE_TEST, Set.of("//java/example:ExampleTest"));
+  }
+
+  @Test
   public void addedTarget_native() throws Exception {
     doTest(Commits.ONE_TEST, Commits.TWO_TESTS, Set.of("//java/example:OtherExampleTest"));
   }
@@ -509,6 +514,8 @@ public abstract class Tests {
 }
 
 class Commits {
+
+  public static final String NO_TARGETS = "6682820b4acb455f13bc3cf8f7d254056092e306";
   public static final String ONE_TEST = "21024914188b0a8aaf88f81a5b9dfbdf3b24dca5";
   public static final String TWO_TESTS = "d00fdc57fad09fbdc1a9b9e53ce0a102e813fd1a";
   public static final String HAS_JVM_FLAGS = "3d22ee76c892762fc979eaf0be10019f56c82995";


### PR DESCRIPTION
Handle invalid "before" queries

This does not change the behaviour of an "after" query errors.

These may occur when e.g. a `--targets` flag names a directory which was
added between `before` and `after`.

In this case, we treat all detected tests which match the `query` at
`after` as affected. This may lead to some over-triggering,
e.g. suppose we had the target:
* `//foo`

And the query:
`//foo/... + //bar/...`
If we created `//bar`, this would cause us to trigger `//foo` even
though it was not affected.

There's no way for us to programatically detect whether the query failed
because of a missing directory or some other reason, so we either need
to error to the user and leave them to manually resolve the issue, or
fall back to over-triggering targets. Over-triggering seems generally
safe (as there are for sure other cases where we'll over-trigger, e.g.
where source code had comment-only changes which led to the same
tests/binaries being produced), so we'll do the slightly more friendly
thing.