### PR TITLE
Error if allowOverBuilds is unnecessarily set

### DIFF
--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
@@ -187,11 +187,18 @@ public abstract class Tests {
   }
 
   @Test
-  public void tryImportInBazelrcAffectingJava() throws Exception {
+  public void tryImportMissing() throws Exception {
     doTest(
         Commits.TWO_LANGUAGES_OF_TESTS,
         Commits.TWO_LANGUAGES_OPTIONAL_MISSING_TRY_IMPORT,
         Set.of());
+  }
+
+  @Test
+  public void tryImportInBazelrcAffectingJava() throws Exception {
+    allowOverBuilds(
+        "Configuration calculation doesn't appear to trim java fragments from sh_test"
+            + " configuration, so Java changes are viewed to also affect sh_test targets");
     doTest(
         Commits.TWO_LANGUAGES_OPTIONAL_MISSING_TRY_IMPORT,
         Commits.TWO_LANGUAGES_OPTIONAL_PRESENT_BAZELRC_AFFECTING_JAVA,

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Util.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Util.java
@@ -1,6 +1,7 @@
 package com.github.bazel_contrib.target_determinator.integration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 
 import com.github.bazel_contrib.target_determinator.label.Label;
@@ -53,6 +54,8 @@ public class Util {
           "Extra targets were found - this isn't the end of the world, but causes over-building",
           extraTargets,
           empty());
+    } else if (allowOverBuilds) {
+      assertThat("allowOverBuilds is set but no over-building was done", extraTargets, not(empty()));
     }
   }
 


### PR DESCRIPTION
This helps keep the test suite clean and up to date.