### PR TITLE
Accept Bazel startup options

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -67,6 +67,7 @@ func (e *EnforceCleanFlag) Set(value string) error {
 type CommonFlags struct {
 	WorkingDirectory     *string
 	BazelPath            *string
+	BazelOpts            *string
 	EnforceCleanRepo     EnforceCleanFlag
 	DeleteCachedWorktree bool
 	IgnoredFiles         *IgnoreFileFlag
@@ -82,6 +83,7 @@ func RegisterCommonFlags() *CommonFlags {
 	commonFlags := CommonFlags{
 		WorkingDirectory:     StrPtr(),
 		BazelPath:            StrPtr(),
+		BazelOpts:            StrPtr(),
 		EnforceCleanRepo:     AllowIgnored,
 		DeleteCachedWorktree: false,
 		IgnoredFiles:         &IgnoreFileFlag{},
@@ -90,6 +92,8 @@ func RegisterCommonFlags() *CommonFlags {
 	flag.StringVar(commonFlags.WorkingDirectory, "working-directory", ".", "Working directory to query.")
 	flag.StringVar(commonFlags.BazelPath, "bazel", "bazel",
 		"Bazel binary (basename on $PATH, or absolute or relative path) to run.")
+	flag.StringVar(commonFlags.BazelOpts, "bazel-opts", "bazel-opts",
+		"Startup options to pass to Bazel.")
 	flag.Var(&commonFlags.EnforceCleanRepo, "enforce-clean",
 		fmt.Sprintf("Pass --enforce-clean=%v to fail if the repository is unclean, or --enforce-clean=%v to allow ignored untracked files (the default).",
 			EnforceClean.String(), AllowIgnored.String()))
@@ -137,7 +141,10 @@ func ResolveCommonConfig(commonFlags *CommonFlags, beforeRevStr string) (*Common
 		return nil, fmt.Errorf("failed to resolve the \"after\" (i.e. original) git revision: %w", err)
 	}
 
-	bazelCmd := pkg.DefaultBazelCmd{BazelPath: *commonFlags.BazelPath}
+	bazelCmd := pkg.DefaultBazelCmd{
+		BazelPath: *commonFlags.BazelPath,
+		BazelOpts: *commonFlags.BazelOpts,
+	}
 
 	outputBase, err := pkg.BazelOutputBase(workingDirectory, bazelCmd)
 	if err != nil {

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -67,7 +67,7 @@ func (e *EnforceCleanFlag) Set(value string) error {
 type CommonFlags struct {
 	WorkingDirectory     *string
 	BazelPath            *string
-	BazelOpts            *string
+	BazelStartupOpts     *string
 	EnforceCleanRepo     EnforceCleanFlag
 	DeleteCachedWorktree bool
 	IgnoredFiles         *IgnoreFileFlag
@@ -83,7 +83,7 @@ func RegisterCommonFlags() *CommonFlags {
 	commonFlags := CommonFlags{
 		WorkingDirectory:     StrPtr(),
 		BazelPath:            StrPtr(),
-		BazelOpts:            StrPtr(),
+		BazelStartupOpts:     StrPtr(),
 		EnforceCleanRepo:     AllowIgnored,
 		DeleteCachedWorktree: false,
 		IgnoredFiles:         &IgnoreFileFlag{},
@@ -92,7 +92,7 @@ func RegisterCommonFlags() *CommonFlags {
 	flag.StringVar(commonFlags.WorkingDirectory, "working-directory", ".", "Working directory to query.")
 	flag.StringVar(commonFlags.BazelPath, "bazel", "bazel",
 		"Bazel binary (basename on $PATH, or absolute or relative path) to run.")
-	flag.StringVar(commonFlags.BazelOpts, "bazel-opts", "bazel-opts",
+	flag.StringVar(commonFlags.BazelStartupOpts, "bazel-startup-opts", "bazel-startup-opts",
 		"Startup options to pass to Bazel.")
 	flag.Var(&commonFlags.EnforceCleanRepo, "enforce-clean",
 		fmt.Sprintf("Pass --enforce-clean=%v to fail if the repository is unclean, or --enforce-clean=%v to allow ignored untracked files (the default).",
@@ -142,8 +142,8 @@ func ResolveCommonConfig(commonFlags *CommonFlags, beforeRevStr string) (*Common
 	}
 
 	bazelCmd := pkg.DefaultBazelCmd{
-		BazelPath: *commonFlags.BazelPath,
-		BazelOpts: *commonFlags.BazelOpts,
+		BazelPath:        *commonFlags.BazelPath,
+		BazelStartupOpts: *commonFlags.BazelStartupOpts,
 	}
 
 	outputBase, err := pkg.BazelOutputBase(workingDirectory, bazelCmd)

--- a/pkg/bazel.go
+++ b/pkg/bazel.go
@@ -23,12 +23,13 @@ type BazelCmd interface {
 
 type DefaultBazelCmd struct {
 	BazelPath string
+	BazelOpts string
 }
 
 // Execute calls bazel with the provided arguments.
 // It returns the exit status code or -1 if it errored before the process could start.
 func (c DefaultBazelCmd) Execute(config BazelCmdConfig, args ...string) (int, error) {
-	cmd := exec.Command(c.BazelPath, args...)
+	cmd := exec.Command(c.BazelPath, append([]string{c.BazelOpts}, args...)...)
 	cmd.Dir = config.Dir
 	cmd.Stdout = config.Stdout
 	cmd.Stderr = config.Stderr

--- a/pkg/bazel.go
+++ b/pkg/bazel.go
@@ -22,14 +22,14 @@ type BazelCmd interface {
 }
 
 type DefaultBazelCmd struct {
-	BazelPath string
-	BazelOpts string
+	BazelPath        string
+	BazelStartupOpts string
 }
 
 // Execute calls bazel with the provided arguments.
 // It returns the exit status code or -1 if it errored before the process could start.
 func (c DefaultBazelCmd) Execute(config BazelCmdConfig, args ...string) (int, error) {
-	cmd := exec.Command(c.BazelPath, append([]string{c.BazelOpts}, args...)...)
+	cmd := exec.Command(c.BazelPath, append([]string{c.BazelStartupOpts}, args...)...)
 	cmd.Dir = config.Dir
 	cmd.Stdout = config.Stdout
 	cmd.Stderr = config.Stderr

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
@@ -168,6 +168,13 @@ public class TargetDeterminatorSpecificFlagsTest {
     assertThat(output, containsString("-source 7 -target 7"));
   }
 
+  @Test
+  public void startupOptsIgnoringBazelrc() throws Exception {
+    TestdataRepo.gitCheckout(testDir, Commits.BAZELRC_TEST_ENV);
+    Set<Label> targets = getTargets(Commits.TWO_LANGUAGES_OF_TESTS, "//...", false, true, List.of("--bazel-startup-opts=--noworkspace_rc"));
+    Util.assertTargetsMatch(targets, Set.of(), Set.of(), false);
+  }
+
   private Set<Label> getTargets(String commitBefore, String targets) throws Exception {
     return getTargets(commitBefore, targets, false, true);
   }


### PR DESCRIPTION
Allows passing bazel startup options, like `--noworkspace_rc`, which
can't be set in the RC files.

Fixes #25
