### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: build
-        run: mkdir .release-artifacts && cp $(bazel build --show_result=9999 target-determinator:all driver:all 2>&1 | grep 'bazel-out') .release-artifacts/
+        run: bazel build //target-determinator:all //driver:all && mkdir .release-artifacts && for f in $(bazel cquery --output=files 'let bins = kind(go_binary, //target-determinator:all  + //driver:all) in $bins - attr(tags, "\bmanual\b", $bins)'); do cp "$(bazel info execution_root)/${f}" .release-artifacts/; done
       - name: release
         uses: softprops/action-gh-release@v1
         with:

--- a/rules/multi_platform_go_binary.bzl
+++ b/rules/multi_platform_go_binary.bzl
@@ -8,15 +8,20 @@ _PLATFORMS = [
     ("windows", "amd64"),
 ]
 
-def multi_platform_go_binary(name, **kwargs):
+def multi_platform_go_binary(name, tags = None, **kwargs):
     if "visibility" not in kwargs:
         kwargs["visibility"] = "//visibility:public"
 
     if "goos" in kwargs or "goarch" in kwargs:
         fail("Can't specify goos or goarch for multi_platform_go_binary")
 
+    unplatformed_binary_tags = [t for t in tags or []]
+    if "manual" not in unplatformed_binary_tags:
+        unplatformed_binary_tags.append("manual")
+
     go_binary(
         name = name,
+        tags = unplatformed_binary_tags,
         **kwargs
     )
 
@@ -25,5 +30,6 @@ def multi_platform_go_binary(name, **kwargs):
             name = "{}.{}.{}".format(name, goos, goarch),
             goos = goos,
             goarch = goarch,
+            tags = tags,
             **kwargs
         )


### PR DESCRIPTION
Upgrading bazel from 5.1.1 to 5.3.1 changed these output paths. Fortunately, it also brought us a new API for retrieving them! Let's use it.