### PR TITLE
Move  com_github_tidwall_gjson to "root" to fix static resolution issues

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -126,9 +126,11 @@ rules_proto_dependencies()
 
 rules_proto_toolchains()
 
-# workaround for https://github.com/bazelbuild/bazel-gazelle/pull/1201
 # see https://github.com/bazelbuild/bazel-gazelle/issues/1344
-## gazelle:repository go_repository name=com_github_tidwall_gjson importpath=github.com/tidwall/gjson
+# github.com/tidwall/gjson is a transitive dependency of github.com/wI2L/jsondiff.
+# due to static resolution mode, com_github_tidwall_gjson will be missing from
+# the deps of generated go_repository rules.  Moving it to the WORKSPACE is a workaround
+# for https://github.com/bazelbuild/bazel-gazelle/pull/1201.
 go_repository(
     name = "com_github_tidwall_gjson",
     importpath = "github.com/tidwall/gjson",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,9 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-# workaround for https://github.com/bazelbuild/bazel-gazelle/pull/1201
-# see https://github.com/bazelbuild/bazel-gazelle/issues/1344
-# gazelle:repository go_repository name=com_github_tidwall_gjson importpath=github.com/tidwall/gjson
-
 http_archive(
     name = "bazel_gazelle",
     sha256 = "efbbba6ac1a4fd342d5122cbdfdb82aeb2cf2862e35022c752eaddffada7c3f3",
@@ -31,7 +27,7 @@ go_rules_dependencies()
 
 go_register_toolchains(version = "1.18")
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 gazelle_dependencies()
 
@@ -129,3 +125,13 @@ load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_
 rules_proto_dependencies()
 
 rules_proto_toolchains()
+
+# workaround for https://github.com/bazelbuild/bazel-gazelle/pull/1201
+# see https://github.com/bazelbuild/bazel-gazelle/issues/1344
+## gazelle:repository go_repository name=com_github_tidwall_gjson importpath=github.com/tidwall/gjson
+go_repository(
+    name = "com_github_tidwall_gjson",
+    importpath = "github.com/tidwall/gjson",
+    sum = "h1:6aeJ0bzojgWLa82gDQHcx3S0Lr/O51I9bJ5nv6JFx5w=",
+    version = "v1.14.0",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,9 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# workaround for https://github.com/bazelbuild/bazel-gazelle/pull/1201
+# see https://github.com/bazelbuild/bazel-gazelle/issues/1344
+# gazelle:repository go_repository name=com_github_tidwall_gjson importpath=github.com/tidwall/gjson
+
 http_archive(
     name = "bazel_gazelle",
     sha256 = "efbbba6ac1a4fd342d5122cbdfdb82aeb2cf2862e35022c752eaddffada7c3f3",
@@ -27,7 +31,7 @@ go_rules_dependencies()
 
 go_register_toolchains(version = "1.18")
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 
 gazelle_dependencies()
 

--- a/scripts/update-dependencies
+++ b/scripts/update-dependencies
@@ -10,13 +10,6 @@ bazel run @go_sdk//:bin/go -- mod tidy
 echo -e 'def go_dependencies():\n    pass\n' >third_party/go/deps.bzl
 bazel run //:gazelle -- update-repos -from_file=go.mod -prune -to_macro "third_party/go/deps.bzl%go_dependencies"
 
-# Work around https://github.com/bazelbuild/bazel-gazelle/issues/1344
-sed_i=(sed -i)
-if [[ "$(uname)" == "Darwin" ]]; then
-  sed_i+=("")
-fi
-"${sed_i[@]}" 's#load("@bazel_gazelle//:deps\.bzl", "go_repository")#load("//:third_party/go/go_repository.bzl", "go_repository")#' third_party/go/deps.bzl
-
 mv "${SCRIPT_DIR}"/../third_party/go/bazel_differ_deps.bzl.bak "${SCRIPT_DIR}"/../third_party/go/bazel_differ_deps.bzl
 
 "${SCRIPT_DIR}"/format

--- a/third_party/go/deps.bzl
+++ b/third_party/go/deps.bzl
@@ -290,12 +290,6 @@ def go_dependencies():
         version = "v0.0.0-20191217153810-f85b25db303b",
     )
     go_repository(
-        name = "com_github_tidwall_gjson",
-        importpath = "github.com/tidwall/gjson",
-        sum = "h1:6aeJ0bzojgWLa82gDQHcx3S0Lr/O51I9bJ5nv6JFx5w=",
-        version = "v1.14.0",
-    )
-    go_repository(
         name = "com_github_tidwall_match",
         importpath = "github.com/tidwall/match",
         sum = "h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=",

--- a/third_party/go/deps.bzl
+++ b/third_party/go/deps.bzl
@@ -1,4 +1,4 @@
-load("//:third_party/go/go_repository.bzl", "go_repository")
+load("@bazel_gazelle//:deps.bzl", "go_repository")
 
 def go_dependencies():
     go_repository(

--- a/third_party/go/go_repository.bzl
+++ b/third_party/go/go_repository.bzl
@@ -1,9 +1,0 @@
-load("@bazel_gazelle//:deps.bzl", _go_repository = "go_repository")
-
-def go_repository(**kwargs):
-    if "build_external" in kwargs:
-        fail("Saw build_external in go_repository shim kwargs")
-
-    # Work around https://github.com/bazelbuild/bazel-gazelle/issues/1344
-    kwargs["build_external"] = "external"
-    _go_repository(**kwargs)


### PR DESCRIPTION
Relates to https://github.com/bazel-contrib/target-determinator/pull/28.

I recently had to deal with this issue as well, documented my findings in https://github.com/stackb/rules_proto/pull/287.  When I saw https://github.com/bazelbuild/bazel-gazelle/issues/1344 I figured I'd send a PR with what might be a better workaround.