### PR TITLE
Add option to skip analysis cache clearing

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -106,7 +106,7 @@ func RegisterCommonFlags() *CommonFlags {
 		"Files to ignore for git operations, relative to the working-directory. These files shan't affect the Bazel graph.")
 	flag.StringVar(commonFlags.TargetsFlag, "targets", "//...",
 		"Targets to consider. Accepts any valid `bazel query` expression (see https://bazel.build/reference/query).")
-	flag.StringVar(commonFlags.AnalysisCacheClearStrategy, "analysis-cache-clear-strategy", "shutdown", "Strategy for clearing the analysis cache. Accept values: shutdown,discard.")
+	flag.StringVar(commonFlags.AnalysisCacheClearStrategy, "analysis-cache-clear-strategy", "skip", "Strategy for clearing the analysis cache. Accept values: skip,shutdown,discard.")
 	flag.BoolVar(&commonFlags.CompareQueriesAroundAnalysisCacheClear, "compare-queries-around-analysis-cache-clear", false, "Whether to check for query result differences before and after analysis cache clears. This is a temporary flag for performing real-world analysis.")
 	return &commonFlags
 }

--- a/pkg/target_determinator.go
+++ b/pkg/target_determinator.go
@@ -110,7 +110,10 @@ type Context struct {
 	// IgnoredFiles represents files that should be ignored for git operations.
 	IgnoredFiles []common.RelPath
 	// AnalysisCacheClearStrategy is the strategy used for clearing the Bazel analysis cache before cquery runs.
-	// Accepted values are: shutdown, discard.
+	// Accepted values are: skip, shutdown, discard.
+	// We currently don't believe clearing this cache is necessary.
+	//
+	// skip will not clear the analysis cache between cquery runs.
 	//
 	// shutdown will shut down the bazel server before queries.
 	// discard will run a build with --discard_analysis_cache before queries.
@@ -561,7 +564,9 @@ type LabelAndConfiguration struct {
 }
 
 func clearAnalysisCache(context *Context) error {
-	if context.AnalysisCacheClearStrategy == "shutdown" {
+	if context.AnalysisCacheClearStrategy == "skip" {
+		return nil
+	} else if context.AnalysisCacheClearStrategy == "shutdown" {
 		result, err := context.BazelCmd.Execute(BazelCmdConfig{Dir: context.WorkspacePath}, "--output_base", context.BazelOutputBase, "shutdown")
 		if result != 0 || err != nil {
 			return fmt.Errorf("failed to discard Bazel analysis cache in %v", context.WorkspacePath)

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
@@ -193,7 +193,6 @@ public class TargetDeterminatorSpecificFlagsTest {
     final List<String> args = Stream.concat(
         Stream.of("--working-directory",
             testDir.toString(),
-            "--analysis-cache-clear-strategy=discard",
             "--bazel", "bazelisk",
             "--targets", targets
         ),


### PR DESCRIPTION
Discussions with the Bazel team at BazelCon suggested this was no longer necessary, and having run extensively with
--compare-queries-around-analysis-cache-clear, we haven't seen any issues with this.

I'm leaving the old options here as fallback in case we run into issues in the future, so it's easy to work around them.

This should significantly speed up target determinator, as the second set of queries should generally be much faster than when the whole universe needed re-evaluating.