### PR TITLE
Allow specifying options for bazel commands

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -68,6 +68,7 @@ type CommonFlags struct {
 	WorkingDirectory                       *string
 	BazelPath                              *string
 	BazelStartupOpts                       *MultipleStrings
+	BazelOpts                              *MultipleStrings
 	EnforceCleanRepo                       EnforceCleanFlag
 	DeleteCachedWorktree                   bool
 	IgnoredFiles                           *IgnoreFileFlag
@@ -86,6 +87,7 @@ func RegisterCommonFlags() *CommonFlags {
 		WorkingDirectory:                       StrPtr(),
 		BazelPath:                              StrPtr(),
 		BazelStartupOpts:                       &MultipleStrings{},
+		BazelOpts:                              &MultipleStrings{},
 		EnforceCleanRepo:                       AllowIgnored,
 		DeleteCachedWorktree:                   false,
 		IgnoredFiles:                           &IgnoreFileFlag{},
@@ -97,6 +99,7 @@ func RegisterCommonFlags() *CommonFlags {
 	flag.StringVar(commonFlags.BazelPath, "bazel", "bazel",
 		"Bazel binary (basename on $PATH, or absolute or relative path) to run.")
 	flag.Var(commonFlags.BazelStartupOpts, "bazel-startup-opts", "Startup options to pass to Bazel.")
+	flag.Var(commonFlags.BazelOpts, "bazel-opts", "Options to pass to Bazel. Assumed to apply to build and cquery.")
 	flag.Var(&commonFlags.EnforceCleanRepo, "enforce-clean",
 		fmt.Sprintf("Pass --enforce-clean=%v to fail if the repository is unclean, or --enforce-clean=%v to allow ignored untracked files (the default).",
 			EnforceClean.String(), AllowIgnored.String()))
@@ -149,6 +152,7 @@ func ResolveCommonConfig(commonFlags *CommonFlags, beforeRevStr string) (*Common
 	bazelCmd := pkg.DefaultBazelCmd{
 		BazelPath:        *commonFlags.BazelPath,
 		BazelStartupOpts: *commonFlags.BazelStartupOpts,
+		BazelOpts:        *commonFlags.BazelOpts,
 	}
 
 	outputBase, err := pkg.BazelOutputBase(workingDirectory, bazelCmd)

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -111,7 +111,7 @@ func main() {
 	log.Printf("Running %s on %d targets", commandVerb, len(targets))
 	result, err := config.Context.BazelCmd.Execute(
 		pkg.BazelCmdConfig{Dir: config.Context.WorkspacePath, Stdout: os.Stdout, Stderr: os.Stderr},
-		commandVerb, "--target_pattern_file", targetPatternFile.Name())
+		nil, commandVerb, "--target_pattern_file", targetPatternFile.Name())
 
 	if result != 0 || err != nil {
 		log.Fatal(err)

--- a/pkg/bazel.go
+++ b/pkg/bazel.go
@@ -18,19 +18,32 @@ type BazelCmdConfig struct {
 }
 
 type BazelCmd interface {
-	Execute(config BazelCmdConfig, args ...string) (int, error)
+	Execute(config BazelCmdConfig, startupArgs []string, command string, args ...string) (int, error)
 }
 
 type DefaultBazelCmd struct {
 	BazelPath        string
 	BazelStartupOpts []string
+	BazelOpts        []string
+}
+
+// Commands which we should apply BazelOpts to.
+// This is an incomplete list, but includes all of the commands we actually use in the target determinator.
+var _buildLikeCommands = map[string]struct{}{
+	"build":  {},
+	"cquery": {},
 }
 
 // Execute calls bazel with the provided arguments.
 // It returns the exit status code or -1 if it errored before the process could start.
-func (c DefaultBazelCmd) Execute(config BazelCmdConfig, args ...string) (int, error) {
+func (c DefaultBazelCmd) Execute(config BazelCmdConfig, startupArgs []string, command string, args ...string) (int, error) {
 	bazelArgv := make([]string, 0, len(c.BazelStartupOpts)+len(args))
 	bazelArgv = append(bazelArgv, c.BazelStartupOpts...)
+	bazelArgv = append(bazelArgv, startupArgs...)
+	bazelArgv = append(bazelArgv, command)
+	if _, ok := _buildLikeCommands[command]; ok {
+		bazelArgv = append(bazelArgv, c.BazelOpts...)
+	}
 	bazelArgv = append(bazelArgv, args...)
 	cmd := exec.Command(c.BazelPath, bazelArgv...)
 	cmd.Dir = config.Dir

--- a/pkg/configurations.go
+++ b/pkg/configurations.go
@@ -35,7 +35,7 @@ func getConfigurationDetails(context *Context) (map[Configuration]singleConfigur
 
 	returnVal, err := context.BazelCmd.Execute(
 		BazelCmdConfig{Dir: context.WorkspacePath, Stdout: &stdout, Stderr: &stderr},
-		"--output_base", context.BazelOutputBase, "config", "--output=json", "--dump_all")
+		[]string{"--output_base", context.BazelOutputBase}, "config", "--output=json", "--dump_all")
 
 	if returnVal != 0 || err != nil {
 		return nil, fmt.Errorf("failed to run bazel config --output=json --dump_all: %w. Stderr:\n%v", err, stderr.String())

--- a/pkg/target_determinator.go
+++ b/pkg/target_determinator.go
@@ -567,7 +567,7 @@ func clearAnalysisCache(context *Context) error {
 	if context.AnalysisCacheClearStrategy == "skip" {
 		return nil
 	} else if context.AnalysisCacheClearStrategy == "shutdown" {
-		result, err := context.BazelCmd.Execute(BazelCmdConfig{Dir: context.WorkspacePath}, "--output_base", context.BazelOutputBase, "shutdown")
+		result, err := context.BazelCmd.Execute(BazelCmdConfig{Dir: context.WorkspacePath}, []string{"--output_base", context.BazelOutputBase}, "shutdown")
 		if result != 0 || err != nil {
 			return fmt.Errorf("failed to discard Bazel analysis cache in %v", context.WorkspacePath)
 		}
@@ -578,7 +578,7 @@ func clearAnalysisCache(context *Context) error {
 
 			result, err := context.BazelCmd.Execute(
 				BazelCmdConfig{Dir: context.WorkspacePath, Stderr: &stderr},
-				"--output_base", context.BazelOutputBase, "build", "--discard_analysis_cache")
+				[]string{"--output_base", context.BazelOutputBase}, "build", "--discard_analysis_cache")
 
 			if result != 0 || err != nil {
 				return fmt.Errorf("failed to discard Bazel analysis cache in %v: %w. Stderr from Bazel ↓↓\n%v", context.WorkspacePath, err, stderr.String())
@@ -592,7 +592,7 @@ func clearAnalysisCache(context *Context) error {
 
 			result, err := context.BazelCmd.Execute(
 				BazelCmdConfig{Dir: context.WorkspacePath, Stderr: &stderr},
-				"--output_base", context.BazelOutputBase, "build")
+				[]string{"--output_base", context.BazelOutputBase}, "build")
 
 			if result != 0 || err != nil {
 				return fmt.Errorf("failed to run no-op build after discarding Bazel analysis cache in %v: %w. Stderr:\n%v",
@@ -618,7 +618,7 @@ func bazelInfo(workingDirectory string, bazelCmd BazelCmd, key string) (string, 
 
 	result, err := bazelCmd.Execute(
 		BazelCmdConfig{Dir: workingDirectory, Stdout: &stdoutBuf, Stderr: &stderrBuf},
-		"info", key)
+		nil, "info", key)
 
 	if result != 0 || err != nil {
 		return "", fmt.Errorf("failed to get the Bazel %v: %w. Stderr:\n%v", key, err, stderrBuf.String())
@@ -708,7 +708,7 @@ func runToCqueryResult(context *Context, pattern string) (*analysis.CqueryResult
 
 	returnVal, err := context.BazelCmd.Execute(
 		BazelCmdConfig{Dir: context.WorkspacePath, Stdout: &stdout, Stderr: &stderr},
-		"--output_base", context.BazelOutputBase, "cquery", "--output=proto", pattern)
+		[]string{"--output_base", context.BazelOutputBase}, "cquery", "--output=proto", pattern)
 
 	if returnVal != 0 || err != nil {
 		return nil, fmt.Errorf("failed to run cquery on %s: %w. Stderr:\n%v", pattern, err, stderr.String())


### PR DESCRIPTION
This currently lacks a test - the best way I can think of for testing this involves using a select in a target, and having a flag change which branch of the select we hit, but this test actually working depends on a feature I haven't PR'd up yet. Test to come soon as a follow-up PR!

Fixes #39