### PR TITLE
Allow customising behavior on before query errors

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -72,6 +72,7 @@ type CommonFlags struct {
 	EnforceCleanRepo                       EnforceCleanFlag
 	DeleteCachedWorktree                   bool
 	IgnoredFiles                           *IgnoreFileFlag
+	BeforeQueryErrorBehavior               *string
 	TargetsFlag                            *string
 	AnalysisCacheClearStrategy             *string
 	CompareQueriesAroundAnalysisCacheClear bool
@@ -91,6 +92,7 @@ func RegisterCommonFlags() *CommonFlags {
 		EnforceCleanRepo:                       AllowIgnored,
 		DeleteCachedWorktree:                   false,
 		IgnoredFiles:                           &IgnoreFileFlag{},
+		BeforeQueryErrorBehavior:               StrPtr(),
 		TargetsFlag:                            StrPtr(),
 		AnalysisCacheClearStrategy:             StrPtr(),
 		CompareQueriesAroundAnalysisCacheClear: false,
@@ -107,9 +109,10 @@ func RegisterCommonFlags() *CommonFlags {
 		"Delete created worktrees after use when created. Keeping them can make subsequent invocations faster.")
 	flag.Var(commonFlags.IgnoredFiles, "ignore-file",
 		"Files to ignore for git operations, relative to the working-directory. These files shan't affect the Bazel graph.")
+	flag.StringVar(commonFlags.BeforeQueryErrorBehavior, "before-query-error-behavior", "ignore-and-build-all", "How to behave if the 'before' revision query fails. Accepted values: fatal,ignore-and-build-all")
 	flag.StringVar(commonFlags.TargetsFlag, "targets", "//...",
 		"Targets to consider. Accepts any valid `bazel query` expression (see https://bazel.build/reference/query).")
-	flag.StringVar(commonFlags.AnalysisCacheClearStrategy, "analysis-cache-clear-strategy", "skip", "Strategy for clearing the analysis cache. Accept values: skip,shutdown,discard.")
+	flag.StringVar(commonFlags.AnalysisCacheClearStrategy, "analysis-cache-clear-strategy", "skip", "Strategy for clearing the analysis cache. Accepted values: skip,shutdown,discard.")
 	flag.BoolVar(&commonFlags.CompareQueriesAroundAnalysisCacheClear, "compare-queries-around-analysis-cache-clear", false, "Whether to check for query result differences before and after analysis cache clears. This is a temporary flag for performing real-world analysis.")
 	return &commonFlags
 }
@@ -167,6 +170,7 @@ func ResolveCommonConfig(commonFlags *CommonFlags, beforeRevStr string) (*Common
 		BazelOutputBase:                        outputBase,
 		DeleteCachedWorktree:                   commonFlags.DeleteCachedWorktree,
 		IgnoredFiles:                           *commonFlags.IgnoredFiles,
+		BeforeQueryErrorBehavior:               *commonFlags.BeforeQueryErrorBehavior,
 		AnalysisCacheClearStrategy:             *commonFlags.AnalysisCacheClearStrategy,
 		CompareQueriesAroundAnalysisCacheClear: commonFlags.CompareQueriesAroundAnalysisCacheClear,
 	}

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDiffIntegrationTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDiffIntegrationTest.java
@@ -64,6 +64,7 @@ public class BazelDiffIntegrationTest extends Tests {
       if (processBuilder.start().waitFor() != 0) {
         throw new TargetComputationErrorException(
             String.format("Expected exit code 0 when running %s", Joiner.on(" ").join(argv)),
+            "",
             "");
       }
     } catch (IOException | InterruptedException e) {

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDifferIntegrationTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDifferIntegrationTest.java
@@ -57,6 +57,7 @@ public class BazelDifferIntegrationTest extends Tests {
       if (processBuilder.start().waitFor() != 0) {
         throw new TargetComputationErrorException(
             String.format("Expected exit code 0 when running %s", Joiner.on(" ").join(argv)),
+            "",
             "");
       }
     } catch (IOException | InterruptedException e) {

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetComputationErrorException.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetComputationErrorException.java
@@ -3,17 +3,26 @@ package com.github.bazel_contrib.target_determinator.integration;
 /** TargetComputationErrorException represents an error when computing targets. */
 class TargetComputationErrorException extends Exception {
 
-  private final String output;
+  private final String stdout;
+  private final String stderr;
 
   /**
-   * getOutput returns the stdout of the failed command.
+   * getStdout returns the stdout of the failed command.
    */
-  public String getOutput() {
-    return output;
+  public String getStdout() {
+    return stdout;
   }
 
-  public TargetComputationErrorException(String errorMessage, String output) {
+  /**
+   * getStderr returns the stdout of the failed command.
+   */
+  public String getStderr() {
+    return stderr;
+  }
+
+  public TargetComputationErrorException(String errorMessage, String stdout, String stderr) {
     super(errorMessage);
-    this.output = output;
+    this.stdout = stdout;
+    this.stderr = stderr;
   }
 }

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminator.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminator.java
@@ -55,7 +55,7 @@ public class TargetDeterminator {
     }
     processBuilder.directory(workingDirectory.toFile());
     processBuilder.redirectOutput(Redirect.PIPE);
-    processBuilder.redirectError(Redirect.INHERIT);
+    processBuilder.redirectError(Redirect.PIPE);
     // Do not clean the environment, so we can inherit variables passed e.g. via --test_env.
     // Useful for CC (needed by bazel).
     processBuilder.environment().put("HOME", System.getProperty("user.home"));
@@ -63,13 +63,15 @@ public class TargetDeterminator {
     try {
       Process process = processBuilder.start();
       final String output = new String(ByteStreams.toByteArray(process.getInputStream()), StandardCharsets.UTF_8);
+      final String stderr = new String(ByteStreams.toByteArray(process.getErrorStream()), StandardCharsets.UTF_8);
       final int returnCode = process.waitFor();
       if (returnCode != 0) {
         throw new TargetComputationErrorException(
             String.format(
                 "Expected exit code 0 when running %s but got: %d",
                 Joiner.on(" ").join(argv), returnCode),
-            output);
+            output,
+            stderr);
       }
       return output;
     } catch (IOException | InterruptedException e) {

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorIntegrationTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorIntegrationTest.java
@@ -99,7 +99,7 @@ public class TargetDeterminatorIntegrationTest extends Tests {
           Commits.REDUCE_DEPENDENCY_VISIBILITY,
           Set.of("//NotApplicable"));
     } catch (TargetComputationErrorException e) {
-      assertThat(e.getOutput(), CoreMatchers.equalTo("Target Determinator invocation Error\n"));
+      assertThat(e.getStdout(), CoreMatchers.equalTo("Target Determinator invocation Error\n"));
       return;
     }
     fail("Expected target-determinator command to fail but it succeeded");

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
@@ -100,6 +100,18 @@ public class TargetDeterminatorSpecificFlagsTest {
   }
 
   @Test
+  public void targetPatternFlagQueryBeforeWasErrorWhenFatal() throws Exception {
+    TestdataRepo.gitCheckout(testDir, Commits.ONE_TEST);
+    try {
+      String output = getOutput(Commits.NO_TARGETS, "//java/...", false, true, List.of("--before-query-error-behavior=fatal"));
+      fail(String.format("Expected exception but got successful output: %s", output));
+    } catch (TargetComputationErrorException e) {
+      assertThat(e.getStdout(), CoreMatchers.equalTo("Target Determinator invocation Error\n"));
+      assertThat(e.getStderr(), containsString("failed to query at revision 'before'"));
+    }
+  }
+
+  @Test
   public void failForUncleanRepositoryWithEnforceClean() throws Exception {
     TestdataRepo.gitCheckout(testDir, Commits.HAS_JVM_FLAGS);
 
@@ -109,7 +121,7 @@ public class TargetDeterminatorSpecificFlagsTest {
       getTargets(Commits.TWO_TESTS, "//...", true, true);
       fail("Expected target-determinator command to fail but it succeeded");
     } catch (TargetComputationErrorException e) {
-      assertThat(e.getOutput(), CoreMatchers.equalTo("Target Determinator invocation Error\n"));
+      assertThat(e.getStdout(), CoreMatchers.equalTo("Target Determinator invocation Error\n"));
     }
   }
 
@@ -137,7 +149,7 @@ public class TargetDeterminatorSpecificFlagsTest {
           "//...", true, true);
       fail("Expected target-determinator command to fail but it succeeded");
     } catch (TargetComputationErrorException e) {
-      assertThat(e.getOutput(), CoreMatchers.equalTo("Target Determinator invocation Error\n"));
+      assertThat(e.getStdout(), CoreMatchers.equalTo("Target Determinator invocation Error\n"));
     }
   }
 


### PR DESCRIPTION
In very large repos, just running everything may be problematically expensive, and users may instead want to just hard error.