### PR TITLE
Filter incompatible targets

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -76,6 +76,7 @@ type CommonFlags struct {
 	TargetsFlag                            *string
 	AnalysisCacheClearStrategy             *string
 	CompareQueriesAroundAnalysisCacheClear bool
+	FilterIncompatibleTargets              bool
 }
 
 func StrPtr() *string {
@@ -96,6 +97,7 @@ func RegisterCommonFlags() *CommonFlags {
 		TargetsFlag:                            StrPtr(),
 		AnalysisCacheClearStrategy:             StrPtr(),
 		CompareQueriesAroundAnalysisCacheClear: false,
+		FilterIncompatibleTargets:              true,
 	}
 	flag.StringVar(commonFlags.WorkingDirectory, "working-directory", ".", "Working directory to query.")
 	flag.StringVar(commonFlags.BazelPath, "bazel", "bazel",
@@ -114,6 +116,7 @@ func RegisterCommonFlags() *CommonFlags {
 		"Targets to consider. Accepts any valid `bazel query` expression (see https://bazel.build/reference/query).")
 	flag.StringVar(commonFlags.AnalysisCacheClearStrategy, "analysis-cache-clear-strategy", "skip", "Strategy for clearing the analysis cache. Accepted values: skip,shutdown,discard.")
 	flag.BoolVar(&commonFlags.CompareQueriesAroundAnalysisCacheClear, "compare-queries-around-analysis-cache-clear", false, "Whether to check for query result differences before and after analysis cache clears. This is a temporary flag for performing real-world analysis.")
+	flag.BoolVar(&commonFlags.FilterIncompatibleTargets, "filter-incompatible-targets", true, "Whether to filter out incompatible targets from the candidate set of affected targets.")
 	return &commonFlags
 }
 
@@ -173,6 +176,7 @@ func ResolveCommonConfig(commonFlags *CommonFlags, beforeRevStr string) (*Common
 		BeforeQueryErrorBehavior:               *commonFlags.BeforeQueryErrorBehavior,
 		AnalysisCacheClearStrategy:             *commonFlags.AnalysisCacheClearStrategy,
 		CompareQueriesAroundAnalysisCacheClear: commonFlags.CompareQueriesAroundAnalysisCacheClear,
+		FilterIncompatibleTargets:              commonFlags.FilterIncompatibleTargets,
 	}
 
 	// Non-context attributes

--- a/pkg/target_determinator.go
+++ b/pkg/target_determinator.go
@@ -765,6 +765,9 @@ func findCompatibleTargets(context *Context, pattern string) (map[label.Label]bo
 	scanner := bufio.NewScanner(&stdout)
 	for scanner.Scan() {
 		labelStr := scanner.Text()
+		if labelStr == "" {
+			continue
+		}
 		label, err := ParseCanonicalLabel(labelStr)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse label from compatibility-filtering: %q: %w", labelStr, err)

--- a/pkg/target_determinator.go
+++ b/pkg/target_determinator.go
@@ -760,7 +760,7 @@ func findCompatibleTargets(context *Context, pattern string) (map[string]bool, e
 		"--starlark:expr=target.label if \"IncompatiblePlatformProvider\" not in providers(target) else \"\"",
 	)
 	if returnVal != 0 || err != nil {
-		return nil, fmt.Errorf("failed to run cquery on %s: %w. Stderr:\n%v", pattern, err, stderr.String())
+		return nil, fmt.Errorf("failed to run compatibility-filtering cquery on %s: %w. Stderr:\n%v", pattern, err, stderr.String())
 	}
 
 	compatibleTargets := make(map[string]bool)

--- a/pkg/target_determinator.go
+++ b/pkg/target_determinator.go
@@ -765,7 +765,7 @@ func findCompatibleTargets(context *Context, pattern string) (map[label.Label]bo
 	scanner := bufio.NewScanner(&stdout)
 	for scanner.Scan() {
 		labelStr := scanner.Text()
-		label, err := label.Parse(labelStr)
+		label, err := ParseCanonicalLabel(labelStr)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse label from compatibility-filtering: %q: %w", labelStr, err)
 		}
@@ -832,15 +832,15 @@ func ParseCqueryResult(result *analysis.CqueryResult) (map[label.Label]map[Confi
 func labelOf(target *build.Target) (label.Label, error) {
 	switch target.GetType() {
 	case build.Target_RULE:
-		return label.Parse(target.GetRule().GetName())
+		return ParseCanonicalLabel(target.GetRule().GetName())
 	case build.Target_SOURCE_FILE:
-		return label.Parse(target.GetSourceFile().GetName())
+		return ParseCanonicalLabel(target.GetSourceFile().GetName())
 	case build.Target_GENERATED_FILE:
-		return label.Parse(target.GetGeneratedFile().GetName())
+		return ParseCanonicalLabel(target.GetGeneratedFile().GetName())
 	case build.Target_PACKAGE_GROUP:
-		return label.Parse(target.GetPackageGroup().GetName())
+		return ParseCanonicalLabel(target.GetPackageGroup().GetName())
 	case build.Target_ENVIRONMENT_GROUP:
-		return label.Parse(target.GetEnvironmentGroup().GetName())
+		return ParseCanonicalLabel(target.GetEnvironmentGroup().GetName())
 	default:
 		return label.NoLabel, fmt.Errorf("labelOf called on unknown target type: %v", target.GetType().String())
 	}

--- a/pkg/walker.go
+++ b/pkg/walker.go
@@ -33,7 +33,7 @@ func WalkAffectedTargets(context *Context, revBefore LabelledGitRev, targets Tar
 	}
 
 	for _, l := range afterMetadata.MatchingTargets.Labels() {
-		if err := diffSingleLabel(context, beforeMetadata, afterMetadata, includeDifferences, l, callback); err != nil {
+		if err := DiffSingleLabel(beforeMetadata, afterMetadata, includeDifferences, l, callback); err != nil {
 			return err
 		}
 	}
@@ -41,11 +41,8 @@ func WalkAffectedTargets(context *Context, revBefore LabelledGitRev, targets Tar
 	return nil
 }
 
-func diffSingleLabel(context *Context, beforeMetadata, afterMetadata *QueryResults, includeDifferences bool, label label.Label, callback WalkCallback) error {
+func DiffSingleLabel(beforeMetadata, afterMetadata *QueryResults, includeDifferences bool, label label.Label, callback WalkCallback) error {
 	for _, configuration := range afterMetadata.MatchingTargets.ConfigurationsFor(label) {
-		if !hasConfiguredTarget(context, label, configuration) {
-			continue
-		}
 		configuredTarget := afterMetadata.TransitiveConfiguredTargets[label][configuration]
 
 		var differences []Difference
@@ -118,14 +115,4 @@ func diffSingleLabel(context *Context, beforeMetadata, afterMetadata *QueryResul
 		}
 	}
 	return nil
-}
-
-func hasConfiguredTarget(context *Context, label label.Label, configuration Configuration) bool {
-	// Calling "bazel cquery config(<label>, configuration)" attempts to find the
-	// configured target for the label. If no results can be found, the query fails:
-	// https://bazel.build/query/cquery#config
-	_, err := context.BazelCmd.Execute(
-		BazelCmdConfig{Dir: context.WorkspacePath},
-		[]string{"--output_base", context.BazelOutputBase}, "cquery", fmt.Sprintf("config(%s,%s)", label, configuration))
-	return err == nil
 }

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BUILD.bazel
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BUILD.bazel
@@ -77,6 +77,7 @@ java_test(
     jvm_flags = [
         "-Dtarget_determinator=$(rootpath //target-determinator)",
     ],
+    shard_count = 2,
     tags = ["no-sandbox"],
     deps = [
         ":tests",

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDiffIntegrationTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDiffIntegrationTest.java
@@ -143,4 +143,8 @@ public class BazelDiffIntegrationTest extends Tests {
   @Override
   @Ignore("bazel-diff doesn't check file modes")
   public void testChmodFile() {}
+
+  @Override
+  @Ignore("bazel-diff does not filter incompatible targets")
+  public void incompatibleTargetsAreFiltered() throws Exception {}
 }

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDifferIntegrationTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDifferIntegrationTest.java
@@ -180,4 +180,8 @@ public class BazelDifferIntegrationTest extends Tests {
   @Override
   @Ignore("bazel-differ doesn't handle no targets being returned from a query")
   public void zeroToOneTarget_native() {}
+
+  @Override
+  @Ignore("bazel-differ does not filter incompatible targets")
+  public void incompatibleTargetsAreFiltered() throws Exception {}
 }

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
@@ -484,8 +484,10 @@ public abstract class Tests {
   }
 
   @Test
-  public void incompatibleTargetsAreFiltered() throws TargetComputationErrorException {
-    doTest(Commits.NO_TARGETS, Commits.INCOMPATIBLE_TARGET, Set.of("//java/example:CompatibleTest"));
+  public void incompatibleTargetsAreFiltered() throws Exception {
+    doTest(Commits.ONE_TEST, Commits.INCOMPATIBLE_TARGET,
+        Set.of("//java/example:CompatibleTest"),
+        Set.of("//java/example:IncompatibleTest"));
   }
 
   public void doTest(String commitBefore, String commitAfter, Set<String> expectedTargets) throws TargetComputationErrorException {

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
@@ -6,6 +6,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 
 import com.github.bazel_contrib.target_determinator.label.Label;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
@@ -482,6 +483,11 @@ public abstract class Tests {
     doTest(Commits.ONE_SH_TEST, Commits.SH_TEST_NOT_EXECUTABLE, Set.of("//sh:sh_test"));
   }
 
+  @Test
+  public void incompatibleTargetsAreFiltered() throws TargetComputationErrorException {
+    doTest(Commits.NO_TARGETS, Commits.INCOMPATIBLE_TARGET, Set.of("//java/example:CompatibleTest"));
+  }
+
   public void doTest(String commitBefore, String commitAfter, Set<String> expectedTargets) throws TargetComputationErrorException {
     doTest(commitBefore, commitAfter, expectedTargets, Set.of());
   }
@@ -606,4 +612,6 @@ class Commits {
       "ff7e60d535564a0695a5bf9ed1774bacc480bf50"; // (v1/sh-test) add an executable shell file and BUILD.bazel file
   public static final String SH_TEST_NOT_EXECUTABLE =
       "6452291f3dcea1a5cdb332463308b70325a833e0"; // (v1/sh-test-non-executable) make shell file non-executable
+  public static final String INCOMPATIBLE_TARGET =
+      "69b4567d904cad46a584901c82c2959be89ae458";
 }


### PR DESCRIPTION
For some reason, cquery returns incompatible targets that need to be filtered using the config operator.