### PR TITLE
Don't persist bazel caches across runs

### DIFF
--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -6,8 +6,5 @@ build --announce_rc
 # Don't rely on test logs being easily accessible from the test runner,
 # though it makes the log noisier.
 test --test_output=errors
-# This directory is configured in GitHub actions to be persisted between runs.
-build --disk_cache=$HOME/.cache/bazel
-build --repository_cache=$HOME/.cache/bazel-repo
 # Allows tests to run bazelisk-in-bazel, since this is the cache folder used
 test --test_env=XDG_CACHE_HOME

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -11,18 +11,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Check dependencies and format
         run: scripts/update-dependencies && scripts/format && { [[ -z "$(git status --porcelain)" ]] || exit 1; }
-      - name: Mount bazel action cache
-        uses: actions/cache@v3
-        with:
-          path: "~/.cache/bazel"
-          key: bazel
-      - name: Mount bazel repo cache
-        uses: actions/cache@v3
-        with:
-          path: "~/.cache/bazel-repo"
-          key: bazel-repo
       - name: bazel test //...
         env:
-          # Bazelisk will download bazel to here, ensure it is cached between runs.
+          # Bazelisk will download bazel to here, ensure it is cached within tests.
           XDG_CACHE_HOME: /home/runner/.cache/bazel-repo
         run: bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...


### PR DESCRIPTION
Target determinator is pretty fast to build, and the tests almost never get cache hits.

The cache is currently 4.5GB.

Downloading it is slower than just re-building things, and we're likely to re-run the tests regardless.