### PR TITLE
Disable configuration-specific narrowing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/bazelbuild/bazel-gazelle v0.25.1-0.20220406134132-bd319f810c16
 	github.com/google/btree v1.1.2
 	github.com/google/uuid v1.3.0
-	github.com/hashicorp/go-version v1.6.0
 	github.com/otiai10/copy v1.7.1-0.20211223015809-9aae5f77261f
 	github.com/wI2L/jsondiff v0.2.0
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
-github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/otiai10/copy v1.7.1-0.20211223015809-9aae5f77261f h1:P7Ab27T4In6ExIHmjOe88b1BHpuHlr4Vr75hX2QKAXw=
 github.com/otiai10/copy v1.7.1-0.20211223015809-9aae5f77261f/go.mod h1:rmRl6QPdJj6EiUqXQ/4Nn2lLXoNQjFCQbbNrxgc/t3U=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//third_party/protobuf/bazel/build",
         "@bazel_gazelle//label:go_default_library",
         "@com_github_aristanetworks_goarista//path",
-        "@com_github_hashicorp_go_version//:go-version",
         "@com_github_wi2l_jsondiff//:jsondiff",
         "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_google_protobuf//proto",

--- a/pkg/configurations.go
+++ b/pkg/configurations.go
@@ -8,6 +8,33 @@ import (
 	"github.com/wI2L/jsondiff"
 )
 
+type Configuration struct {
+	inner string
+}
+
+func NormalizeConfiguration(c string) Configuration {
+	if c == "null" {
+		return Configuration{
+			inner: "",
+		}
+	}
+	return Configuration{
+		inner: c,
+	}
+}
+
+func (c *Configuration) String() string {
+	return c.inner
+}
+
+func (c *Configuration) ForHashing() []byte {
+	return []byte(c.inner)
+}
+
+func ConfigurationLess(l, r Configuration) bool {
+	return l.inner < r.inner
+}
+
 func diffConfigurations(l, r singleConfigurationOutput) (string, error) {
 	patch, err := jsondiff.Compare(l, r)
 	if err != nil {
@@ -49,7 +76,7 @@ func getConfigurationDetails(context *Context) (map[Configuration]singleConfigur
 	}
 	m := make(map[Configuration]singleConfigurationOutput)
 	for _, c := range configurations {
-		configuration := Configuration(c.ConfigHash)
+		configuration := NormalizeConfiguration(c.ConfigHash)
 		if _, ok := m[configuration]; ok {
 			return nil, fmt.Errorf("saw duplicate configuration for %q", configuration)
 		}

--- a/pkg/hash_cache.go
+++ b/pkg/hash_cache.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -18,7 +17,6 @@ import (
 	"github.com/bazel-contrib/target-determinator/third_party/protobuf/bazel/analysis"
 	"github.com/bazel-contrib/target-determinator/third_party/protobuf/bazel/build"
 	gazelle_label "github.com/bazelbuild/bazel-gazelle/label"
-	"github.com/hashicorp/go-version"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -40,18 +38,8 @@ func NewTargetHashCache(context map[gazelle_label.Label]map[Configuration]*analy
 }
 
 func isConfiguredRuleInputsSupported(releaseString string) bool {
-	releasePrefix := "release "
-	explanation := " - assuming cquery does not support configured rule inputs (which is supported since bazel 6), which may lead to over-estimates of affected targets"
-	if !strings.HasPrefix(releaseString, releasePrefix) {
-		log.Printf("Bazel wasn't a released version%s", explanation)
-		return false
-	}
-	v, err := version.NewVersion(releaseString[len(releasePrefix):])
-	if err != nil {
-		log.Printf("Failed to parse Bazel version %q: %s", releaseString, explanation)
-		return false
-	}
-	return v.GreaterThanOrEqual(version.Must(version.NewVersion("6.0.0")))
+	// Disabled until https://github.com/bazelbuild/bazel/issues/17916 is resolved
+	return false
 }
 
 // TargetHashCache caches hash computations for targets and files, so that transitive hashes can be

--- a/pkg/hash_cache_test.go
+++ b/pkg/hash_cache_test.go
@@ -160,7 +160,7 @@ func TestDigestTree(t *testing.T) {
 
 	labelAndConfiguration := pkg.LabelAndConfiguration{
 		Label:         mustParseLabel("//HelloWorld:HelloWorld"),
-		Configuration: configurationChecksum,
+		Configuration: pkg.NormalizeConfiguration(configurationChecksum),
 	}
 
 	const defaultBazelVersion = "release 5.1.1"

--- a/pkg/walker.go
+++ b/pkg/walker.go
@@ -74,8 +74,8 @@ func DiffSingleLabel(beforeMetadata, afterMetadata *QueryResults, includeDiffere
 					diff, _ := diffConfigurations(beforeMetadata.configurations[configurationsBefore[0]], afterMetadata.configurations[configurationsAfter[0]])
 					difference = Difference{
 						Category: "ChangedConfiguration",
-						Before:   string(configurationsBefore[0]),
-						After:    string(configurationsAfter[0]),
+						Before:   configurationsBefore[0].String(),
+						After:    configurationsAfter[0].String(),
 						Key:      diff,
 					}
 				}

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorIntegrationTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorIntegrationTest.java
@@ -66,6 +66,15 @@ public class TargetDeterminatorIntegrationTest extends Tests {
   }
 
   @Override
+  public void addingTargetUsedInHostConfiguration() throws Exception {
+    allowOverBuilds(
+        "cquery doesn't factor configuration into ruleInputs, so we can't differentiate between"
+            + " host and target deps. See"
+            + " https://github.com/bazelbuild/bazel/issues/14610#issuecomment-1024460141");
+    super.addingTargetUsedInHostConfiguration();
+  }
+
+  @Override
   public void changingHostConfigurationDoesNotAffectTargetConfiguration() throws Exception {
     allowOverBuilds(
         "cquery doesn't factor configuration into ruleInputs, so we can't differentiate between"
@@ -97,5 +106,11 @@ public class TargetDeterminatorIntegrationTest extends Tests {
       assertThat(e.getStdout(), CoreMatchers.equalTo("Target Determinator invocation Error\n"));
       assertThat(e.getStderr(), CoreMatchers.containsString("target '//java/example/simple:simple' is not visible from target '//java/example:ExampleTest'"));
     }
+  }
+
+  @Override
+  public void ignoredPlatformSpecificDepChanged() throws Exception {
+    allowOverBuilds("Platform-specific narrowing is disabled due to https://github.com/bazelbuild/bazel/issues/17916");
+    super.ignoredPlatformSpecificDepChanged();
   }
 }

--- a/third_party/go/deps.bzl
+++ b/third_party/go/deps.bzl
@@ -122,12 +122,6 @@ def go_dependencies():
         version = "v1.0.2",
     )
     go_repository(
-        name = "com_github_hashicorp_go_version",
-        importpath = "github.com/hashicorp/go-version",
-        sum = "h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=",
-        version = "v1.6.0",
-    )
-    go_repository(
         name = "com_github_influxdata_influxdb1_client",
         importpath = "github.com/influxdata/influxdb1-client",
         sum = "h1:HqW4xhhynfjrtEiiSGcQUd6vrK23iMam1FO8rI7mwig=",


### PR DESCRIPTION
Bazel currently returns insufficient information in more complex cases.

Also, normalize configurations a bit better.