### PR TITLE
Force gazelle to use third_party gazelle dep

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@bazel_gazelle//:def.bzl", "gazelle")
 
+# gazelle:resolve go github.com/bazelbuild/bazel-gazelle/label @com_github_bazelbuild_bazel_gazelle//label
+
 # gazelle:prefix github.com/bazel-contrib/target-determinator
 gazelle(
     name = "gazelle",

--- a/scripts/format
+++ b/scripts/format
@@ -9,3 +9,5 @@ echo "importsort" >&2
 find $(pwd) -type f -name '*.go' |
     grep -v ".pb.go" |
     xargs bazel run --noshow_progress --ui_event_filters= @com_github_aristanetworks_goarista//cmd/importsort -- -w -s NOT_SPECIFIED
+
+bazel run //:gazelle


### PR DESCRIPTION
https://github.com/bazel-contrib/target-determinator/pull/61 attempted to do this, but running gazelle undoes it - instead, tell gazelle to keep preserving this property.