### PR TITLE
Support using configured rule inputs from 7.0.0 prereleases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/bazelbuild/bazel-gazelle v0.30.1-0.20230501114844-23226de73881
 	github.com/google/btree v1.1.2
 	github.com/google/uuid v1.3.0
+	github.com/hashicorp/go-version v1.6.0
 	github.com/otiai10/copy v1.7.1-0.20211223015809-9aae5f77261f
 	github.com/wI2L/jsondiff v0.2.0
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/otiai10/copy v1.7.1-0.20211223015809-9aae5f77261f h1:P7Ab27T4In6ExIHmjOe88b1BHpuHlr4Vr75hX2QKAXw=
 github.com/otiai10/copy v1.7.1-0.20211223015809-9aae5f77261f/go.mod h1:rmRl6QPdJj6EiUqXQ/4Nn2lLXoNQjFCQbbNrxgc/t3U=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//third_party/protobuf/bazel/build",
         "@com_github_aristanetworks_goarista//path",
         "@com_github_bazelbuild_bazel_gazelle//label",
+        "@com_github_hashicorp_go_version//:go-version",
         "@com_github_wi2l_jsondiff//:jsondiff",
         "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_google_protobuf//proto",

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorIntegrationTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorIntegrationTest.java
@@ -65,6 +65,7 @@ public class TargetDeterminatorIntegrationTest extends Tests {
     super.tryImportInBazelrcAffectingJava();
   }
 
+  // TODO: Stop ignoring this test when our tests use Bazel 7.0.0
   @Override
   public void addingTargetUsedInHostConfiguration() throws Exception {
     allowOverBuilds(
@@ -108,6 +109,7 @@ public class TargetDeterminatorIntegrationTest extends Tests {
     }
   }
 
+  // TODO: Stop ignoring this test when our tests use Bazel 7.0.0
   @Override
   public void ignoredPlatformSpecificDepChanged() throws Exception {
     allowOverBuilds("Platform-specific narrowing is disabled due to https://github.com/bazelbuild/bazel/issues/17916");

--- a/third_party/go/deps.bzl
+++ b/third_party/go/deps.bzl
@@ -122,6 +122,12 @@ def go_dependencies():
         version = "v1.0.2",
     )
     go_repository(
+        name = "com_github_hashicorp_go_version",
+        importpath = "github.com/hashicorp/go-version",
+        sum = "h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=",
+        version = "v1.6.0",
+    )
+    go_repository(
         name = "com_github_influxdata_influxdb1_client",
         importpath = "github.com/influxdata/influxdb1-client",
         sum = "h1:HqW4xhhynfjrtEiiSGcQUd6vrK23iMam1FO8rI7mwig=",


### PR DESCRIPTION
This allows for more precise dependency analysis as we no longer need to guess configurations (where we over-estimate), and avoids potential deadlocks if we hit dependency cycles.

Fixes #72