### PR TITLE
Fix error reporting for git checkout of original rev

### DIFF
--- a/pkg/target_determinator.go
+++ b/pkg/target_determinator.go
@@ -169,7 +169,7 @@ func fullyProcessRevision(context *Context, rev LabelledGitRev, targets TargetsL
 	defer func() {
 		innerErr := gitCheckout(context.WorkspacePath, context.OriginalRevision)
 		if innerErr != nil && err == nil {
-			err = fmt.Errorf("failed to check out original commit during cleanup: %v", err)
+			err = fmt.Errorf("failed to check out original commit during cleanup: %v", innerErr)
 		}
 	}()
 	queryInfo, loadMetadataCleanup, err := LoadIncompleteMetadata(context, rev, targets)


### PR DESCRIPTION
I noticed this due to problems with MODULE.bazel.lock in bazel 7.

Example failure: https://github.com/carbon-language/carbon-lang/actions/runs/7250904398/job/19752117231?pr=3514

```
2023/12/18 16:30:10 failed to process change: failed to check out original commit during cleanup: <nil>
```

With this change it should look more like:

```
2023/12/18 08:51:19 failed to process change: failed to check out original commit during cleanup: failed to check out revision 'after' (llvm-bzlmod, sha: 67bcc1f551049d5f29f23d33598f0eda73a23151): exit status 1. Output: error: Your local changes to the following files would be overwritten by checkout:
	MODULE.bazel.lock
Please commit your changes or stash them before you switch branches.
```