### PR TITLE
Work around bazel7 incompatible targets issue

### DIFF
--- a/common/versions/BUILD.bazel
+++ b/common/versions/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "versions",
+    srcs = ["versions.go"],
+    importpath = "github.com/bazel-contrib/target-determinator/common/versions",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_hashicorp_go_version//:go-version"],
+)
+
+go_test(
+    name = "versions_test",
+    srcs = ["versions_test.go"],
+    embed = [":versions"],
+    deps = [
+        "@com_github_hashicorp_go_version//:go-version",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/common/versions/versions.go
+++ b/common/versions/versions.go
@@ -1,0 +1,31 @@
+package versions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-version"
+)
+
+func ReleaseIsInRange(releaseString string, min *version.Version, max *version.Version) (*bool, string) {
+	releasePrefix := "release "
+	if !strings.HasPrefix(releaseString, releasePrefix) {
+		return nil, "Bazel wasn't a released version"
+	}
+
+	bazelVersion, err := version.NewVersion(releaseString[len(releasePrefix):])
+	if err != nil {
+		return nil, fmt.Sprintf("Failed to parse Bazel version %q", releaseString)
+	}
+	if min != nil && !bazelVersion.GreaterThanOrEqual(min) {
+		return ptr(false), fmt.Sprintf("Bazel version %s was less than minimum %s", bazelVersion, min.String())
+	}
+	if max != nil && !max.GreaterThan(bazelVersion) {
+		return ptr(false), fmt.Sprintf("Bazel version %s was not less than maximum %s", bazelVersion, max.String())
+	}
+	return ptr(true), ""
+}
+
+func ptr[V any](v V) *V {
+	return &v
+}

--- a/common/versions/versions_test.go
+++ b/common/versions/versions_test.go
@@ -1,0 +1,136 @@
+package versions
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReleaseIsInRange(t *testing.T) {
+	for name, tc := range map[string]struct {
+		bazelReleaseString string
+		min                string
+		max                string
+		wantResult         *bool
+		wantExplanation    string
+	}{
+		"in_range": {
+			bazelReleaseString: "release 7.0.0",
+			min:                "6.4.0",
+			max:                "8.0.0",
+			wantResult:         ptr(true),
+			wantExplanation:    "",
+		},
+		"at_max": {
+			bazelReleaseString: "release 7.0.0",
+			min:                "6.4.0",
+			max:                "7.0.0",
+			wantResult:         ptr(false),
+			wantExplanation:    "Bazel version 7.0.0 was not less than maximum 7.0.0",
+		},
+		"at_min": {
+			bazelReleaseString: "release 7.0.0",
+			min:                "7.0.0",
+			max:                "8.0.0",
+			wantResult:         ptr(true),
+			wantExplanation:    "",
+		},
+		"above_max": {
+			bazelReleaseString: "release 7.0.0",
+			min:                "6.4.0",
+			max:                "6.5.0",
+			wantResult:         ptr(false),
+			wantExplanation:    "Bazel version 7.0.0 was not less than maximum 6.5.0",
+		},
+		"below_min": {
+			bazelReleaseString: "release 6.4.0",
+			min:                "7.0.0",
+			max:                "7.1.0",
+			wantResult:         ptr(false),
+			wantExplanation:    "Bazel version 6.4.0 was less than minimum 7.0.0",
+		},
+		"no_release_prefix": {
+			bazelReleaseString: "7.0.0",
+			min:                "6.4.0",
+			max:                "8.0.0",
+			wantResult:         nil,
+			wantExplanation:    "Bazel wasn't a released version",
+		},
+		"no_version": {
+			bazelReleaseString: "release beep",
+			min:                "6.4.0",
+			max:                "8.0.0",
+			wantResult:         nil,
+			wantExplanation:    "Failed to parse Bazel version \"release beep\"",
+		},
+		"prerelease_in_range": {
+			bazelReleaseString: "release 8.0.0-pre.20240101.1",
+			min:                "7.0.0",
+			max:                "8.0.0",
+			wantResult:         ptr(true),
+			wantExplanation:    "",
+		},
+		"prerelease_below_range": {
+			bazelReleaseString: "release 8.0.0-pre.20240101.1",
+			min:                "8.0.0",
+			max:                "8.1.0",
+			wantResult:         ptr(false),
+			wantExplanation:    "Bazel version 8.0.0-pre.20240101.1 was less than minimum 8.0.0",
+		},
+		"prerelease_above_range": {
+			bazelReleaseString: "release 8.0.0-pre.20240101.1",
+			min:                "7.0.0",
+			max:                "7.1.0",
+			wantResult:         ptr(false),
+			wantExplanation:    "Bazel version 8.0.0-pre.20240101.1 was not less than maximum 7.1.0",
+		},
+		"above_only_min": {
+			bazelReleaseString: "release 7.0.0",
+			min:                "6.4.0",
+			max:                "",
+			wantResult:         ptr(true),
+			wantExplanation:    "",
+		},
+		"at_only_min": {
+			bazelReleaseString: "release 6.4.0",
+			min:                "6.4.0",
+			max:                "",
+			wantResult:         ptr(true),
+			wantExplanation:    "",
+		},
+		"below_only_max": {
+			bazelReleaseString: "release 6.4.0",
+			min:                "",
+			max:                "7.0.0",
+			wantResult:         ptr(true),
+			wantExplanation:    "",
+		},
+		"at_only_max": {
+			bazelReleaseString: "release 7.0.0",
+			min:                "",
+			max:                "7.0.0",
+			wantResult:         ptr(false),
+			wantExplanation:    "Bazel version 7.0.0 was not less than maximum 7.0.0",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var min *version.Version
+			if tc.min != "" {
+				min = version.Must(version.NewVersion(tc.min))
+			}
+			var max *version.Version
+			if tc.max != "" {
+				max = version.Must(version.NewVersion(tc.max))
+			}
+			result, explanation := ReleaseIsInRange(tc.bazelReleaseString, min, max)
+			if tc.wantResult == nil {
+				require.Nil(t, result)
+			} else {
+				require.NotNil(t, result)
+				require.Equal(t, *tc.wantResult, *result)
+			}
+			require.Equal(t, tc.wantExplanation, explanation)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -9,14 +9,18 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/otiai10/copy v1.7.1-0.20211223015809-9aae5f77261f
+	github.com/stretchr/testify v1.8.4
 	github.com/wI2L/jsondiff v0.2.0
 	google.golang.org/protobuf v1.27.1
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/tidwall/gjson v1.14.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/tools v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/aristanetworks/goarista v0.0.0-20220211174905-526022c8b178 h1:U7Y+d65
 github.com/aristanetworks/goarista v0.0.0-20220211174905-526022c8b178/go.mod h1:9zxrD1FatJPUgxIsMwWVrALau7/v1sI1OJETI63r670=
 github.com/bazelbuild/bazel-gazelle v0.33.1-0.20231019232305-a957b8358c44 h1:UqVCJ6m6bvESvpIHwynGS2DFZY2S/WtqJFRKl3tRo9Y=
 github.com/bazelbuild/bazel-gazelle v0.33.1-0.20231019232305-a957b8358c44/go.mod h1:6BWjSqjc2gr7YfzMRCbkHiJZy5YRxIKj7iLButu58Jk=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/google/btree v1.1.2 h1:xf4v41cLI2Z6FxbKm+8Bu+m8ifhj15JuZ9sa0jZCMUU=
@@ -19,6 +21,10 @@ github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/otiai10/mint v1.3.3 h1:7JgpsBaN0uMkyju4tbYHu0mnM55hNKVYLsXmwr15NQI=
 github.com/otiai10/mint v1.3.3/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tidwall/gjson v1.14.0 h1:6aeJ0bzojgWLa82gDQHcx3S0Lr/O51I9bJ5nv6JFx5w=
 github.com/tidwall/gjson v1.14.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
@@ -35,3 +41,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//common",
         "//common/sorted_set",
+        "//common/versions",
         "//third_party/protobuf/bazel/analysis",
         "//third_party/protobuf/bazel/build",
         "@com_github_aristanetworks_goarista//path",

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDiffIntegrationTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDiffIntegrationTest.java
@@ -162,4 +162,8 @@ public class BazelDiffIntegrationTest extends Tests {
   @Override
   @Ignore("bazel-diff does not filter incompatible targets")
   public void incompatibleTargetsAreFiltered() throws Exception {}
+
+  @Override
+  @Ignore("bazel-diff does not filter incompatible targets")
+  public void incompatibleTargetsAreFiltered_bazelIssue21010() throws Exception {}
 }

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDifferIntegrationTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDifferIntegrationTest.java
@@ -199,4 +199,8 @@ public class BazelDifferIntegrationTest extends Tests {
   @Override
   @Ignore("bazel-differ does not filter incompatible targets")
   public void incompatibleTargetsAreFiltered() throws Exception {}
+
+  @Override
+  @Ignore("bazel-differ does not filter incompatible targets")
+  public void incompatibleTargetsAreFiltered_bazelIssue21010() throws Exception {}
 }

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
@@ -491,6 +491,13 @@ public abstract class Tests {
   }
 
   @Test
+  public void incompatibleTargetsAreFiltered_bazelIssue21010() throws Exception {
+    doTest(Commits.ONE_TEST_BAZEL7_0_0, Commits.INCOMPATIBLE_TARGET_BAZEL7_0_0,
+        Set.of("//java/example:CompatibleTest"),
+        Set.of("//java/example:IncompatibleTest"));
+  }
+
+  @Test
   public void platformSpecificSrcChanged() throws Exception {
     String after = Commits.CHANGED_NONLINUX_SRC;
     if (isLinux()) {
@@ -601,6 +608,7 @@ class Commits {
 
   public static final String NO_TARGETS = "d2862de5e63c8be0866056e6307049c159fb9e47";
   public static final String ONE_TEST = "65dfed228e75a7f4ad361fe65512a1e58ef83b1c";
+  public static final String ONE_TEST_BAZEL7_0_0 = "30dfd560934f45b8af30601f9d4efe1d5726de5c";
   public static final String TWO_TESTS = "bd1f7781e0d5ee66f3235a1adb8f656d5ea35c2d";
   public static final String HAS_JVM_FLAGS = "50609b7d1260b449ceed57718165981986880d97";
   public static final String EXPLICIT_DEFAULT_VALUE = "34213eb339cbb5d1544c83c1aa8c19528c147e0d";
@@ -682,7 +690,7 @@ class Commits {
       "6452291f3dcea1a5cdb332463308b70325a833e0"; // (v1/sh-test-non-executable) make shell file non-executable
   public static final String INCOMPATIBLE_TARGET =
       "69b4567d904cad46a584901c82c2959be89ae458";
-
+  public static final String INCOMPATIBLE_TARGET_BAZEL7_0_0 = "d2dbc66ed32cb0e95009d2a5d4ce76f3374ddb7d";
   public static final String SELECT_TARGET = "7562088a92cdb20cccb99b996c1c147b0773e60a";
 
   public static final String CHANGED_NONLINUX_SRC = "28310014a760aae84e96254e04337a99bf6b39ea";

--- a/third_party/go/deps.bzl
+++ b/third_party/go/deps.bzl
@@ -290,6 +290,18 @@ def go_dependencies():
         version = "v1.29.1",
     )
     go_repository(
+        name = "com_github_stretchr_objx",
+        importpath = "github.com/stretchr/objx",
+        sum = "h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=",
+        version = "v0.5.0",
+    )
+    go_repository(
+        name = "com_github_stretchr_testify",
+        importpath = "github.com/stretchr/testify",
+        sum = "h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=",
+        version = "v1.8.4",
+    )
+    go_repository(
         name = "com_github_templexxx_cpufeat",
         importpath = "github.com/templexxx/cpufeat",
         sum = "h1:89CEmDvlq/F7SJEOqkIdNDGJXrQIhuIx9D2DBXjavSU=",
@@ -354,6 +366,12 @@ def go_dependencies():
         importpath = "gopkg.in/redis.v4",
         sum = "h1:y3XbwQAiHwgNLUng56mgWYK39vsPqo8sT84XTEcxjr0=",
         version = "v4.2.4",
+    )
+    go_repository(
+        name = "in_gopkg_yaml_v3",
+        importpath = "gopkg.in/yaml.v3",
+        sum = "h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=",
+        version = "v3.0.1",
     )
     go_repository(
         name = "org_golang_google_genproto",


### PR DESCRIPTION
This works around https://github.com/bazelbuild/bazel/issues/21010

We only do this extra filtering when we detect we're running with a
Bazel which suffers from this bug.