### PR TITLE
Have -enforce-clean cause a failure when "before" location is unlcean

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -186,7 +186,7 @@ func ResolveCommonConfig(commonFlags *CommonFlags, beforeRevStr string) (*Common
 		AnalysisCacheClearStrategy:             *commonFlags.AnalysisCacheClearStrategy,
 		CompareQueriesAroundAnalysisCacheClear: commonFlags.CompareQueriesAroundAnalysisCacheClear,
 		FilterIncompatibleTargets:              commonFlags.FilterIncompatibleTargets,
-		EnforceCleanRepo: 					 	commonFlags.EnforceCleanRepo == EnforceClean,
+		EnforceCleanRepo:                       commonFlags.EnforceCleanRepo == EnforceClean,
 	}
 
 	// Non-context attributes

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -187,6 +186,7 @@ func ResolveCommonConfig(commonFlags *CommonFlags, beforeRevStr string) (*Common
 		AnalysisCacheClearStrategy:             *commonFlags.AnalysisCacheClearStrategy,
 		CompareQueriesAroundAnalysisCacheClear: commonFlags.CompareQueriesAroundAnalysisCacheClear,
 		FilterIncompatibleTargets:              commonFlags.FilterIncompatibleTargets,
+		EnforceCleanRepo: 					 	commonFlags.EnforceCleanRepo == EnforceClean,
 	}
 
 	// Non-context attributes
@@ -199,22 +199,6 @@ func ResolveCommonConfig(commonFlags *CommonFlags, beforeRevStr string) (*Common
 	targetsList, err := pkg.ParseTargetsList(*commonFlags.TargetsFlag)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse targets: %w", err)
-	}
-
-	// Additional checks
-
-	uncleanFileStatuses, err := pkg.GitStatusFiltered(workingDirectory, *commonFlags.IgnoredFiles)
-	if err != nil {
-		return nil, fmt.Errorf("failed to check whether the repository is clean: %w", err)
-	}
-
-	if len(uncleanFileStatuses) > 0 && commonFlags.EnforceCleanRepo == EnforceClean {
-		log.Printf("Current working tree has %v non-ignored untracked files:\n",
-			len(uncleanFileStatuses))
-		for _, status := range uncleanFileStatuses {
-			log.Printf("%s\n", status)
-		}
-		return nil, fmt.Errorf("current repository is not clean and --enforce-clean option is set to '%v'. Exiting.", EnforceClean.String())
 	}
 
 	return &CommonConfig{

--- a/pkg/target_determinator.go
+++ b/pkg/target_determinator.go
@@ -378,7 +378,7 @@ func gitSafeCheckout(context *Context, rev LabelledGitRev, ignoredFiles []common
 	}
 	if !isPreCheckoutClean {
 		if context.EnforceCleanRepo {
-			return "", fmt.Errorf("pre-checkout repository is not clean")
+			return "", fmt.Errorf("repository was not clean before checking out %v", rev)
 		}
 
 		log.Printf("Workspace is unclean, using git worktree. This will be slower the first time. " +
@@ -395,7 +395,7 @@ func gitSafeCheckout(context *Context, rev LabelledGitRev, ignoredFiles []common
 		}
 		if !isPostCheckoutClean {
 			if context.EnforceCleanRepo {
-				return "", fmt.Errorf("post-checkout repository is not clean")
+				return "", fmt.Errorf("repository was not clean after checking out %v", rev)
 			}
 
 			log.Printf("Detected unclean repository after checkout (likely due to submodule or " +

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
@@ -137,6 +137,7 @@ public class TargetDeterminatorSpecificFlagsTest {
       fail("Expected target-determinator command to fail but it succeeded");
     } catch (TargetComputationErrorException e) {
       assertThat(e.getStdout(), CoreMatchers.equalTo("Target Determinator invocation Error\n"));
+      assertThat(e.getStderr(), containsString("post-checkout repository is not clean"));
     }
   }
 

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
@@ -126,16 +126,18 @@ public class TargetDeterminatorSpecificFlagsTest {
   }
 
   @Test
-  public void succeedForUncleanIgnoredFilesWithEnforceClean() throws Exception {
+  public void failsForUncleanIgnoredFilesWithEnforceClean() throws Exception {
     TestdataRepo.gitCheckout(testDir, Commits.TWO_TESTS_WITH_GITIGNORE);
 
     Path ignoredFile = testDir.resolve("ignored-file");
     Files.createFile(ignoredFile);
 
-    Set<Label> targets = getTargets(Commits.ONE_TEST, "//...", true, true);
-    Util.assertTargetsMatch(targets, Set.of("//java/example:OtherExampleTest"), Set.of(), false);
-
-    assertThat("expected ignored file to still be present after invocation", ignoredFile.toFile().exists());
+    try {
+      getTargets(Commits.ONE_TEST, "//...", true, true);
+      fail("Expected target-determinator command to fail but it succeeded");
+    } catch (TargetComputationErrorException e) {
+      assertThat(e.getStdout(), CoreMatchers.equalTo("Target Determinator invocation Error\n"));
+    }
   }
 
   @Test

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
@@ -673,6 +673,7 @@ class Commits {
       "c0ef0f9805e65817299eb7a794ed66655c0dd5aa";
   public static final String REDUCE_DEPENDENCY_VISIBILITY =
       "396dae111684b893ec6e04b2f6e86ed603a01082";
+  public static final String ONE_TEST_WITH_GITIGNORE = "51bf9b729dddf35694019c19b5dbffb36bf83af4";
   public static final String TWO_TESTS_WITH_GITIGNORE = "55845a3a08525f2aa66c3d7a2115dad684c46995";
   public static final String SUBMODULE_ADD_TRIVIAL_SUBMODULE =
       "b88ddcfe3da63c8308ce6d3274dd424d2c7b211a";


### PR DESCRIPTION
We encountered a problem where a feature branch had a .gitignored file, but this was not in the main branch `.gitignore`. Even when using `-enforce-clean`, this caused target determinator to identify all targets as changed in the workspace.

This change is to make this situation cause a failure instead.

Closes #85 