### PR TITLE
fix(hash_cache): only take user execute bits into account

### DIFF
--- a/pkg/hash_cache_test.go
+++ b/pkg/hash_cache_test.go
@@ -110,7 +110,7 @@ func TestDigestsSingleSourceFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error hashing file: %v", err)
 	}
-	const want = "33e4ab761182518bbdaabdb916ecea5ad264778881dbe4ce93567f07ea89784b"
+	const want = "321ef2ce71642ec8f05102359c10fb2cef9feb5719065452ffcd18c76077e3c1"
 	got := hex.EncodeToString(hash)
 	if want != got {
 		t.Fatalf("Wrong hash: want %v got %v", want, got)
@@ -411,6 +411,41 @@ func Test_isConfiguredRuleInputsSupported(t *testing.T) {
 			got := isConfiguredRuleInputsSupported(version)
 			if want != got {
 				t.Fatalf("Incorrect isConfiguredRuleInputsSupported: want %v got %v", want, got)
+			}
+		})
+	}
+}
+
+func Test_getUserPermission(t *testing.T) {
+	tests := []struct {
+		fileInfo os.FileMode
+		want     os.FileMode
+	}{
+		{
+			fileInfo: 0777,
+			want:     0100,
+		},
+		{
+			fileInfo: 0177,
+			want:     0100,
+		},
+		{
+			fileInfo: 0111,
+			want:     0100,
+		},
+		{
+			fileInfo: 0664,
+			want:     0000,
+		},
+		{
+			fileInfo: 0644,
+			want:     0000,
+		},
+	}
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			if got := getUserExecuteBit(tt.fileInfo); got != tt.want {
+				t.Errorf("getUserExecuteBit() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDiffIntegrationTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDiffIntegrationTest.java
@@ -148,6 +148,12 @@ public class BazelDiffIntegrationTest extends Tests {
   }
 
   @Override
+  public void changingUnimportantPermissionDoesNotTrigger_native() throws Exception {
+    allowOverBuilds("bazel-diff takes into account all permission bits.");
+    super.changingUnimportantPermissionDoesNotTrigger_native();
+  }
+
+  @Override
   public void refactoringStarlarkRuleIsNoOp() throws Exception {
     allowOverBuilds(
         "Rule implementation attr factors in hashes of entire transitively loaded bzl files, rather"

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDifferIntegrationTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BazelDifferIntegrationTest.java
@@ -181,6 +181,12 @@ public class BazelDifferIntegrationTest extends Tests {
   }
 
   @Override
+  public void changingUnimportantPermissionDoesNotTrigger_native() throws Exception {
+    allowOverBuilds("bazel-differ takes into account all permission bits.");
+    super.changingUnimportantPermissionDoesNotTrigger_native();
+  }
+
+  @Override
   public void refactoringStarlarkRuleIsNoOp() throws Exception {
     allowOverBuilds(
         "Rule implementation attr factors in hashes of entire transitively loaded bzl files, rather"


### PR DESCRIPTION
There are some cases where files are initially created with some permissions (e.g. 775) but are then created by git with different permissions (e.g. 755) when cloning, checking out a branch or creating a worktree. Such differences don't matter to git nor to Bazel; consequently, they should not change the hash of a source file in target-determinator.

The execute bit for ther user (e.g. 744 vs 644) does matter, though, and should be part of the hash.

--

This fixes an issue where TD would spuriously mark targets as changed when they depend on a file that has e.g. 664 permission, and the umask is 022 (the default), when TD uses a git subtree to hash the `before` state.