### PR TITLE
fix: patch regexp pattern until gazelle next release

### DIFF
--- a/third_party/go/deps.bzl
+++ b/third_party/go/deps.bzl
@@ -28,11 +28,11 @@ def go_dependencies():
     go_repository(
         name = "com_github_bazelbuild_bazel_gazelle",
         importpath = "github.com/bazelbuild/bazel-gazelle",
-        sum = "h1:SAYys3KRG5i3KTgQAvO423bLT1rQMSgqEKReMkM/CW0=",
-        version = "v0.40.0",
         patches = [
             "//third_party/patches:gazelle_regexp.patch",
         ],
+        sum = "h1:SAYys3KRG5i3KTgQAvO423bLT1rQMSgqEKReMkM/CW0=",
+        version = "v0.40.0",
     )
     go_repository(
         name = "com_github_bazelbuild_buildtools",

--- a/third_party/go/deps.bzl
+++ b/third_party/go/deps.bzl
@@ -28,9 +28,6 @@ def go_dependencies():
     go_repository(
         name = "com_github_bazelbuild_bazel_gazelle",
         importpath = "github.com/bazelbuild/bazel-gazelle",
-        patches = [
-            "//third_party/patches:gazelle_regexp.patch",
-        ],
         sum = "h1:SAYys3KRG5i3KTgQAvO423bLT1rQMSgqEKReMkM/CW0=",
         version = "v0.40.0",
     )

--- a/third_party/go/deps.bzl
+++ b/third_party/go/deps.bzl
@@ -30,6 +30,9 @@ def go_dependencies():
         importpath = "github.com/bazelbuild/bazel-gazelle",
         sum = "h1:SAYys3KRG5i3KTgQAvO423bLT1rQMSgqEKReMkM/CW0=",
         version = "v0.40.0",
+        patches = [
+            "//third_party/patches:gazelle_regexp.patch",
+        ],
     )
     go_repository(
         name = "com_github_bazelbuild_buildtools",

--- a/third_party/go/go_repository.bzl
+++ b/third_party/go/go_repository.bzl
@@ -6,4 +6,11 @@ def go_repository(**kwargs):
 
     # Work around https://github.com/bazelbuild/bazel-gazelle/issues/1344
     kwargs["build_external"] = "external"
+
+    # Work around for https://github.com/bazel-contrib/bazel-gazelle/pull/2021 until new release of bazel-gazelle
+    if kwargs["importpath"] == "github.com/bazelbuild/bazel-gazelle":
+        kwargs["patches"] = [
+            "//third_party/patches:gazelle_regexp.patch",
+        ]
+
     _go_repository(**kwargs)

--- a/third_party/patches/gazelle_regexp.patch
+++ b/third_party/patches/gazelle_regexp.patch
@@ -1,0 +1,13 @@
+diff --git label/label.go label/label.go
+index faf431c..e019b21 100644
+--- label/label.go
++++ label/label.go
+@@ -71,7 +71,7 @@ var NoLabel = Label{}
+ var (
+ 	// This was taken from https://github.com/bazelbuild/bazel/blob/71fb1e4188b01e582a308cfe4bcbf1c730eded1b/src/main/java/com/google/devtools/build/lib/cmdline/RepositoryName.java#L159C1-L164
+ 	// ~ and + are both allowed as the former is used in canonical repo names by Bazel 7 and earlier and the latter in Bazel 8.
+-	labelRepoRegexp = regexp.MustCompile(`^@$|^[A-Za-z0-9_.-][A-Za-z0-9_.~+-]*$`)
++	labelRepoRegexp = regexp.MustCompile(`^@$|^[A-Za-z0-9_.~+-]*$`)
+ 	// This was taken from https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/cmdline/LabelValidator.java
+ 	// Package names may contain all 7-bit ASCII characters except:
+ 	// 0-31 (control characters)


### PR DESCRIPTION
This applies part of [this patch](https://github.com/bazel-contrib/bazel-gazelle/commit/669939453cba5ac2874407245f02a0d281fd13fa) until a new release of bazel-gazelle is made. 