### PR TITLE
Use `--output=streamed_proto` if supported

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,3 +12,7 @@ common --per_file_copt=external/.*grpc.*@--GRPC_WAS_NOT_SUPPOSED_TO_BE_BUILT
 common --host_per_file_copt=external/.*grpc.*@--GRPC_WAS_NOT_SUPPOSED_TO_BE_BUILT
 
 common --incompatible_enable_proto_toolchain_resolution
+
+# Allow tests to find bazelisk without unnecessary cache thrashing
+common --incompatible_strict_action_env
+common --test_env=PATH

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/wI2L/jsondiff v0.2.0
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d
-	google.golang.org/protobuf v1.33.0
+	google.golang.org/protobuf v1.36.6
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d h1:vU5i/LfpvrRCpgM/VPfJ
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
 golang.org/x/tools/go/vcs v0.1.0-deprecated h1:cOIJqWBl99H1dH5LWizPa+0ImeeJq3t3cJjaeOWUAL4=
 golang.org/x/tools/go/vcs v0.1.0-deprecated/go.mod h1:zUrvATBAvEI9535oC0yWYsLsHIV4Z7g63sNPVMtuBy8=
-google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
-google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
+google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "@com_github_aristanetworks_goarista//path",
         "@com_github_hashicorp_go_version//:go-version",
         "@com_github_wi2l_jsondiff//:jsondiff",
+        "@org_golang_google_protobuf//encoding/protodelim",
         "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_google_protobuf//proto",
     ],

--- a/pkg/hash_cache_test.go
+++ b/pkg/hash_cache_test.go
@@ -381,7 +381,7 @@ func layoutProject(t *testing.T) (string, *analysis.CqueryResult) {
 
 func parseResult(t *testing.T, result *analysis.CqueryResult, bazelRelease string) *TargetHashCache {
 	n := Normalizer{}
-	cqueryResult, err := ParseCqueryResult(result, &n)
+	cqueryResult, err := ParseCqueryResult(result.Results, &n)
 	if err != nil {
 		t.Fatalf("Failed to parse cquery result: %v", err)
 	}


### PR DESCRIPTION
This avoids reading a single giant proto message with all configured targets. Instead, Bazel streams out invidual length-delimited configured target protos, which is more memory efficient and also supports result sizes > 2GB.