### PR TITLE
fix: targets spuriously returned in cache case

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: build
-        run: bazel build --stamp --workspace_status_command=./scripts/workspace-status.sh //target-determinator:all //driver:all && mkdir .release-artifacts && for f in $(bazel cquery --output=files 'let bins = kind(go_binary, //target-determinator:all  + //driver:all) in $bins - attr(tags, "\bmanual\b", $bins)'); do cp "$(bazel info execution_root)/${f}" .release-artifacts/; done
+        run: bazel build --stamp --workspace_status_command=./scripts/workspace-status.sh //target-determinator:all //driver:all //hash-differ:all //hash-persister:all && mkdir .release-artifacts && for f in $(bazel cquery --output=files 'let bins = kind(go_binary, //target-determinator:all  + //driver:all + //hash-differ:all + //hash-persister:all) in $bins - attr(tags, "\bmanual\b", $bins)'); do cp "$(bazel info execution_root)/${f}" .release-artifacts/; done
       - name: release
         uses: softprops/action-gh-release@v1
         with:

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -176,6 +176,133 @@
         ]
       }
     },
+    "@@pybind11_bazel~//:python_configure.bzl%extension": {
+      "general": {
+        "bzlTransitiveDigest": "whINYge95GgPtysKDbNHQ0ZlWYdtKybHs5y2tLF+x7Q=",
+        "usagesDigest": "gNvOHVcAlwgDsNXD0amkv2CC96mnaCThPQoE44y8K+w=",
+        "recordedFileInputs": {
+          "@@pybind11_bazel~//MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e"
+        },
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_config_python": {
+            "bzlFile": "@@pybind11_bazel~//:python_configure.bzl",
+            "ruleClassName": "python_configure",
+            "attributes": {}
+          },
+          "pybind11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file": "@@pybind11_bazel~//:pybind11.BUILD",
+              "strip_prefix": "pybind11-2.11.1",
+              "urls": [
+                "https://github.com/pybind/pybind11/archive/v2.11.1.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "pybind11_bazel~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_fuzzing~//fuzzing/private:extensions.bzl%non_module_dependencies": {
+      "general": {
+        "bzlTransitiveDigest": "hVgJRQ3Er45/UUAgNn1Yp2Khcp/Y8WyafA2kXIYmQ5M=",
+        "usagesDigest": "YnIrdgwnf3iCLfChsltBdZ7yOJh706lpa2vww/i2pDI=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "platforms": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
+                "https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz"
+              ],
+              "sha256": "8150406605389ececb6da07cbcb509d5637a3ab9a24bc69b1101531367d89d74"
+            }
+          },
+          "rules_python": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "d70cd72a7a4880f0000a6346253414825c19cdd40a28289bdf67b8e6480edff8",
+              "strip_prefix": "rules_python-0.28.0",
+              "url": "https://github.com/bazelbuild/rules_python/releases/download/0.28.0/rules_python-0.28.0.tar.gz"
+            }
+          },
+          "bazel_skylib": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz"
+              ]
+            }
+          },
+          "com_google_absl": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/abseil/abseil-cpp/archive/refs/tags/20240116.1.zip"
+              ],
+              "strip_prefix": "abseil-cpp-20240116.1",
+              "integrity": "sha256-7capMWOvWyoYbUaHF/b+I2U6XLMaHmky8KugWvfXYuk="
+            }
+          },
+          "rules_fuzzing_oss_fuzz": {
+            "bzlFile": "@@rules_fuzzing~//fuzzing/private/oss_fuzz:repository.bzl",
+            "ruleClassName": "oss_fuzz_repository",
+            "attributes": {}
+          },
+          "honggfuzz": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file": "@@rules_fuzzing~//:honggfuzz.BUILD",
+              "sha256": "6b18ba13bc1f36b7b950c72d80f19ea67fbadc0ac0bb297ec89ad91f2eaa423e",
+              "url": "https://github.com/google/honggfuzz/archive/2.5.zip",
+              "strip_prefix": "honggfuzz-2.5"
+            }
+          },
+          "rules_fuzzing_jazzer": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_jar",
+            "attributes": {
+              "sha256": "ee6feb569d88962d59cb59e8a31eb9d007c82683f3ebc64955fd5b96f277eec2",
+              "url": "https://repo1.maven.org/maven2/com/code-intelligence/jazzer/0.20.1/jazzer-0.20.1.jar"
+            }
+          },
+          "rules_fuzzing_jazzer_api": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_jar",
+            "attributes": {
+              "sha256": "f5a60242bc408f7fa20fccf10d6c5c5ea1fcb3c6f44642fec5af88373ae7aa1b",
+              "url": "https://repo1.maven.org/maven2/com/code-intelligence/jazzer-api/0.20.1/jazzer-api-0.20.1.jar"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_fuzzing~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@rules_kotlin~//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
         "bzlTransitiveDigest": "fus14IFJ/1LGWWGKPH/U18VnJCoMjfDt1ckahqCnM0A=",
@@ -241,6 +368,805 @@
             "rules_kotlin~",
             "bazel_tools",
             "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_python~//python/extensions:pip.bzl%pip": {
+      "os:osx,arch:aarch64": {
+        "bzlTransitiveDigest": "+BNAES+d411BE6bVfKntzeKwF/tWBjQZVCqmrQ43nr4=",
+        "usagesDigest": "sd8rcaoci4ISeFfwKziIShCKSfTxmRsAh7fAXzX0TRM=",
+        "recordedFileInputs": {
+          "@@rules_fuzzing~//fuzzing/requirements.txt": "ab04664be026b632a0d2a2446c4f65982b7654f5b6851d2f9d399a19b7242a5b",
+          "@@protobuf~//python/requirements.txt": "983be60d3cec4b319dcab6d48aeb3f5b2f7c3350f26b3a9e97486c37967c73c5"
+        },
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "pip_deps_38__groups": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "group_library",
+            "attributes": {
+              "repo_prefix": "pip_deps_38_",
+              "groups": {}
+            }
+          },
+          "pip_deps_38_numpy": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "requirement": "numpy<=1.26.1",
+              "repo": "pip_deps_38",
+              "repo_prefix": "pip_deps_38_",
+              "whl_patches": {},
+              "experimental_target_platforms": [],
+              "python_interpreter": "",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "quiet": true,
+              "timeout": 600,
+              "isolated": true,
+              "extra_pip_args": [],
+              "download_only": false,
+              "pip_data_exclude": [],
+              "enable_implicit_namespace_pkgs": false,
+              "environment": {},
+              "envsubst": [],
+              "group_name": "",
+              "group_deps": []
+            }
+          },
+          "pip_deps_38_setuptools": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "requirement": "setuptools<=70.3.0",
+              "repo": "pip_deps_38",
+              "repo_prefix": "pip_deps_38_",
+              "whl_patches": {},
+              "experimental_target_platforms": [],
+              "python_interpreter": "",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "quiet": true,
+              "timeout": 600,
+              "isolated": true,
+              "extra_pip_args": [],
+              "download_only": false,
+              "pip_data_exclude": [],
+              "enable_implicit_namespace_pkgs": false,
+              "environment": {},
+              "envsubst": [],
+              "group_name": "",
+              "group_deps": []
+            }
+          },
+          "pip_deps_39__groups": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "group_library",
+            "attributes": {
+              "repo_prefix": "pip_deps_39_",
+              "groups": {}
+            }
+          },
+          "pip_deps_39_numpy": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "requirement": "numpy<=1.26.1",
+              "repo": "pip_deps_39",
+              "repo_prefix": "pip_deps_39_",
+              "whl_patches": {},
+              "experimental_target_platforms": [],
+              "python_interpreter": "",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "quiet": true,
+              "timeout": 600,
+              "isolated": true,
+              "extra_pip_args": [],
+              "download_only": false,
+              "pip_data_exclude": [],
+              "enable_implicit_namespace_pkgs": false,
+              "environment": {},
+              "envsubst": [],
+              "group_name": "",
+              "group_deps": []
+            }
+          },
+          "pip_deps_39_setuptools": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "requirement": "setuptools<=70.3.0",
+              "repo": "pip_deps_39",
+              "repo_prefix": "pip_deps_39_",
+              "whl_patches": {},
+              "experimental_target_platforms": [],
+              "python_interpreter": "",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "quiet": true,
+              "timeout": 600,
+              "isolated": true,
+              "extra_pip_args": [],
+              "download_only": false,
+              "pip_data_exclude": [],
+              "enable_implicit_namespace_pkgs": false,
+              "environment": {},
+              "envsubst": [],
+              "group_name": "",
+              "group_deps": []
+            }
+          },
+          "pip_deps_310__groups": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "group_library",
+            "attributes": {
+              "repo_prefix": "pip_deps_310_",
+              "groups": {}
+            }
+          },
+          "pip_deps_310_numpy": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "requirement": "numpy<=1.26.1",
+              "repo": "pip_deps_310",
+              "repo_prefix": "pip_deps_310_",
+              "whl_patches": {},
+              "experimental_target_platforms": [],
+              "python_interpreter": "",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "quiet": true,
+              "timeout": 600,
+              "isolated": true,
+              "extra_pip_args": [],
+              "download_only": false,
+              "pip_data_exclude": [],
+              "enable_implicit_namespace_pkgs": false,
+              "environment": {},
+              "envsubst": [],
+              "group_name": "",
+              "group_deps": []
+            }
+          },
+          "pip_deps_310_setuptools": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "requirement": "setuptools<=70.3.0",
+              "repo": "pip_deps_310",
+              "repo_prefix": "pip_deps_310_",
+              "whl_patches": {},
+              "experimental_target_platforms": [],
+              "python_interpreter": "",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "quiet": true,
+              "timeout": 600,
+              "isolated": true,
+              "extra_pip_args": [],
+              "download_only": false,
+              "pip_data_exclude": [],
+              "enable_implicit_namespace_pkgs": false,
+              "environment": {},
+              "envsubst": [],
+              "group_name": "",
+              "group_deps": []
+            }
+          },
+          "pip_deps_311__groups": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "group_library",
+            "attributes": {
+              "repo_prefix": "pip_deps_311_",
+              "groups": {}
+            }
+          },
+          "pip_deps_311_numpy": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "requirement": "numpy<=1.26.1",
+              "repo": "pip_deps_311",
+              "repo_prefix": "pip_deps_311_",
+              "whl_patches": {},
+              "experimental_target_platforms": [],
+              "python_interpreter": "",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "quiet": true,
+              "timeout": 600,
+              "isolated": true,
+              "extra_pip_args": [],
+              "download_only": false,
+              "pip_data_exclude": [],
+              "enable_implicit_namespace_pkgs": false,
+              "environment": {},
+              "envsubst": [],
+              "group_name": "",
+              "group_deps": []
+            }
+          },
+          "pip_deps_311_setuptools": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "requirement": "setuptools<=70.3.0",
+              "repo": "pip_deps_311",
+              "repo_prefix": "pip_deps_311_",
+              "whl_patches": {},
+              "experimental_target_platforms": [],
+              "python_interpreter": "",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "quiet": true,
+              "timeout": 600,
+              "isolated": true,
+              "extra_pip_args": [],
+              "download_only": false,
+              "pip_data_exclude": [],
+              "enable_implicit_namespace_pkgs": false,
+              "environment": {},
+              "envsubst": [],
+              "group_name": "",
+              "group_deps": []
+            }
+          },
+          "pip_deps_312__groups": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "group_library",
+            "attributes": {
+              "repo_prefix": "pip_deps_312_",
+              "groups": {}
+            }
+          },
+          "pip_deps_312_numpy": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "requirement": "numpy<=1.26.1",
+              "repo": "pip_deps_312",
+              "repo_prefix": "pip_deps_312_",
+              "whl_patches": {},
+              "experimental_target_platforms": [],
+              "python_interpreter": "",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "quiet": true,
+              "timeout": 600,
+              "isolated": true,
+              "extra_pip_args": [],
+              "download_only": false,
+              "pip_data_exclude": [],
+              "enable_implicit_namespace_pkgs": false,
+              "environment": {},
+              "envsubst": [],
+              "group_name": "",
+              "group_deps": []
+            }
+          },
+          "pip_deps_312_setuptools": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "requirement": "setuptools<=70.3.0",
+              "repo": "pip_deps_312",
+              "repo_prefix": "pip_deps_312_",
+              "whl_patches": {},
+              "experimental_target_platforms": [],
+              "python_interpreter": "",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "quiet": true,
+              "timeout": 600,
+              "isolated": true,
+              "extra_pip_args": [],
+              "download_only": false,
+              "pip_data_exclude": [],
+              "enable_implicit_namespace_pkgs": false,
+              "environment": {},
+              "envsubst": [],
+              "group_name": "",
+              "group_deps": []
+            }
+          },
+          "rules_fuzzing_py_deps_38__groups": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "group_library",
+            "attributes": {
+              "repo_prefix": "rules_fuzzing_py_deps_38_",
+              "groups": {}
+            }
+          },
+          "rules_fuzzing_py_deps_38_absl_py": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "requirement": "absl-py==2.0.0 --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3",
+              "repo": "rules_fuzzing_py_deps_38",
+              "repo_prefix": "rules_fuzzing_py_deps_38_",
+              "whl_patches": {},
+              "experimental_target_platforms": [],
+              "python_interpreter": "",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "quiet": true,
+              "timeout": 600,
+              "isolated": true,
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "download_only": false,
+              "pip_data_exclude": [],
+              "enable_implicit_namespace_pkgs": false,
+              "environment": {},
+              "envsubst": [],
+              "group_name": "",
+              "group_deps": []
+            }
+          },
+          "rules_fuzzing_py_deps_38_six": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "requirement": "six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
+              "repo": "rules_fuzzing_py_deps_38",
+              "repo_prefix": "rules_fuzzing_py_deps_38_",
+              "whl_patches": {},
+              "experimental_target_platforms": [],
+              "python_interpreter": "",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "quiet": true,
+              "timeout": 600,
+              "isolated": true,
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "download_only": false,
+              "pip_data_exclude": [],
+              "enable_implicit_namespace_pkgs": false,
+              "environment": {},
+              "envsubst": [],
+              "group_name": "",
+              "group_deps": []
+            }
+          },
+          "rules_fuzzing_py_deps_39__groups": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "group_library",
+            "attributes": {
+              "repo_prefix": "rules_fuzzing_py_deps_39_",
+              "groups": {}
+            }
+          },
+          "rules_fuzzing_py_deps_39_absl_py": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "requirement": "absl-py==2.0.0 --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3",
+              "repo": "rules_fuzzing_py_deps_39",
+              "repo_prefix": "rules_fuzzing_py_deps_39_",
+              "whl_patches": {},
+              "experimental_target_platforms": [],
+              "python_interpreter": "",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "quiet": true,
+              "timeout": 600,
+              "isolated": true,
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "download_only": false,
+              "pip_data_exclude": [],
+              "enable_implicit_namespace_pkgs": false,
+              "environment": {},
+              "envsubst": [],
+              "group_name": "",
+              "group_deps": []
+            }
+          },
+          "rules_fuzzing_py_deps_39_six": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "requirement": "six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
+              "repo": "rules_fuzzing_py_deps_39",
+              "repo_prefix": "rules_fuzzing_py_deps_39_",
+              "whl_patches": {},
+              "experimental_target_platforms": [],
+              "python_interpreter": "",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "quiet": true,
+              "timeout": 600,
+              "isolated": true,
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "download_only": false,
+              "pip_data_exclude": [],
+              "enable_implicit_namespace_pkgs": false,
+              "environment": {},
+              "envsubst": [],
+              "group_name": "",
+              "group_deps": []
+            }
+          },
+          "rules_fuzzing_py_deps_310__groups": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "group_library",
+            "attributes": {
+              "repo_prefix": "rules_fuzzing_py_deps_310_",
+              "groups": {}
+            }
+          },
+          "rules_fuzzing_py_deps_310_absl_py": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "requirement": "absl-py==2.0.0 --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3",
+              "repo": "rules_fuzzing_py_deps_310",
+              "repo_prefix": "rules_fuzzing_py_deps_310_",
+              "whl_patches": {},
+              "experimental_target_platforms": [],
+              "python_interpreter": "",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "quiet": true,
+              "timeout": 600,
+              "isolated": true,
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "download_only": false,
+              "pip_data_exclude": [],
+              "enable_implicit_namespace_pkgs": false,
+              "environment": {},
+              "envsubst": [],
+              "group_name": "",
+              "group_deps": []
+            }
+          },
+          "rules_fuzzing_py_deps_310_six": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "requirement": "six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
+              "repo": "rules_fuzzing_py_deps_310",
+              "repo_prefix": "rules_fuzzing_py_deps_310_",
+              "whl_patches": {},
+              "experimental_target_platforms": [],
+              "python_interpreter": "",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "quiet": true,
+              "timeout": 600,
+              "isolated": true,
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "download_only": false,
+              "pip_data_exclude": [],
+              "enable_implicit_namespace_pkgs": false,
+              "environment": {},
+              "envsubst": [],
+              "group_name": "",
+              "group_deps": []
+            }
+          },
+          "rules_fuzzing_py_deps_311__groups": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "group_library",
+            "attributes": {
+              "repo_prefix": "rules_fuzzing_py_deps_311_",
+              "groups": {}
+            }
+          },
+          "rules_fuzzing_py_deps_311_absl_py": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "requirement": "absl-py==2.0.0 --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3",
+              "repo": "rules_fuzzing_py_deps_311",
+              "repo_prefix": "rules_fuzzing_py_deps_311_",
+              "whl_patches": {},
+              "experimental_target_platforms": [],
+              "python_interpreter": "",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "quiet": true,
+              "timeout": 600,
+              "isolated": true,
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "download_only": false,
+              "pip_data_exclude": [],
+              "enable_implicit_namespace_pkgs": false,
+              "environment": {},
+              "envsubst": [],
+              "group_name": "",
+              "group_deps": []
+            }
+          },
+          "rules_fuzzing_py_deps_311_six": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "requirement": "six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
+              "repo": "rules_fuzzing_py_deps_311",
+              "repo_prefix": "rules_fuzzing_py_deps_311_",
+              "whl_patches": {},
+              "experimental_target_platforms": [],
+              "python_interpreter": "",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "quiet": true,
+              "timeout": 600,
+              "isolated": true,
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "download_only": false,
+              "pip_data_exclude": [],
+              "enable_implicit_namespace_pkgs": false,
+              "environment": {},
+              "envsubst": [],
+              "group_name": "",
+              "group_deps": []
+            }
+          },
+          "rules_fuzzing_py_deps_312__groups": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "group_library",
+            "attributes": {
+              "repo_prefix": "rules_fuzzing_py_deps_312_",
+              "groups": {}
+            }
+          },
+          "rules_fuzzing_py_deps_312_absl_py": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "requirement": "absl-py==2.0.0 --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3",
+              "repo": "rules_fuzzing_py_deps_312",
+              "repo_prefix": "rules_fuzzing_py_deps_312_",
+              "whl_patches": {},
+              "experimental_target_platforms": [],
+              "python_interpreter": "",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "quiet": true,
+              "timeout": 600,
+              "isolated": true,
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "download_only": false,
+              "pip_data_exclude": [],
+              "enable_implicit_namespace_pkgs": false,
+              "environment": {},
+              "envsubst": [],
+              "group_name": "",
+              "group_deps": []
+            }
+          },
+          "rules_fuzzing_py_deps_312_six": {
+            "bzlFile": "@@rules_python~//python/pip_install:pip_repository.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "requirement": "six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
+              "repo": "rules_fuzzing_py_deps_312",
+              "repo_prefix": "rules_fuzzing_py_deps_312_",
+              "whl_patches": {},
+              "experimental_target_platforms": [],
+              "python_interpreter": "",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "quiet": true,
+              "timeout": 600,
+              "isolated": true,
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "download_only": false,
+              "pip_data_exclude": [],
+              "enable_implicit_namespace_pkgs": false,
+              "environment": {},
+              "envsubst": [],
+              "group_name": "",
+              "group_deps": []
+            }
+          },
+          "pip_deps": {
+            "bzlFile": "@@rules_python~//python/private/bzlmod:pip_repository.bzl",
+            "ruleClassName": "pip_repository",
+            "attributes": {
+              "repo_name": "pip_deps",
+              "whl_map": {
+                "numpy": [
+                  "3.8",
+                  "3.9",
+                  "3.10",
+                  "3.11",
+                  "3.12"
+                ],
+                "setuptools": [
+                  "3.8",
+                  "3.9",
+                  "3.10",
+                  "3.11",
+                  "3.12"
+                ]
+              },
+              "default_version": "3.11"
+            }
+          },
+          "rules_fuzzing_py_deps": {
+            "bzlFile": "@@rules_python~//python/private/bzlmod:pip_repository.bzl",
+            "ruleClassName": "pip_repository",
+            "attributes": {
+              "repo_name": "rules_fuzzing_py_deps",
+              "whl_map": {
+                "absl_py": [
+                  "3.8",
+                  "3.9",
+                  "3.10",
+                  "3.11",
+                  "3.12"
+                ],
+                "six": [
+                  "3.8",
+                  "3.9",
+                  "3.10",
+                  "3.11",
+                  "3.12"
+                ]
+              },
+              "default_version": "3.11"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_features~",
+            "bazel_features_globals",
+            "bazel_features~~version_extension~bazel_features_globals"
+          ],
+          [
+            "bazel_features~",
+            "bazel_features_version",
+            "bazel_features~~version_extension~bazel_features_version"
+          ],
+          [
+            "rules_python~",
+            "bazel_features",
+            "bazel_features~"
+          ],
+          [
+            "rules_python~",
+            "bazel_skylib",
+            "bazel_skylib~"
+          ],
+          [
+            "rules_python~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_python~",
+            "pypi__build",
+            "rules_python~~internal_deps~pypi__build"
+          ],
+          [
+            "rules_python~",
+            "pypi__click",
+            "rules_python~~internal_deps~pypi__click"
+          ],
+          [
+            "rules_python~",
+            "pypi__colorama",
+            "rules_python~~internal_deps~pypi__colorama"
+          ],
+          [
+            "rules_python~",
+            "pypi__importlib_metadata",
+            "rules_python~~internal_deps~pypi__importlib_metadata"
+          ],
+          [
+            "rules_python~",
+            "pypi__installer",
+            "rules_python~~internal_deps~pypi__installer"
+          ],
+          [
+            "rules_python~",
+            "pypi__more_itertools",
+            "rules_python~~internal_deps~pypi__more_itertools"
+          ],
+          [
+            "rules_python~",
+            "pypi__packaging",
+            "rules_python~~internal_deps~pypi__packaging"
+          ],
+          [
+            "rules_python~",
+            "pypi__pep517",
+            "rules_python~~internal_deps~pypi__pep517"
+          ],
+          [
+            "rules_python~",
+            "pypi__pip",
+            "rules_python~~internal_deps~pypi__pip"
+          ],
+          [
+            "rules_python~",
+            "pypi__pip_tools",
+            "rules_python~~internal_deps~pypi__pip_tools"
+          ],
+          [
+            "rules_python~",
+            "pypi__pyproject_hooks",
+            "rules_python~~internal_deps~pypi__pyproject_hooks"
+          ],
+          [
+            "rules_python~",
+            "pypi__setuptools",
+            "rules_python~~internal_deps~pypi__setuptools"
+          ],
+          [
+            "rules_python~",
+            "pypi__tomli",
+            "rules_python~~internal_deps~pypi__tomli"
+          ],
+          [
+            "rules_python~",
+            "pypi__wheel",
+            "rules_python~~internal_deps~pypi__wheel"
+          ],
+          [
+            "rules_python~",
+            "pypi__zipp",
+            "rules_python~~internal_deps~pypi__zipp"
+          ],
+          [
+            "rules_python~",
+            "pythons_hub",
+            "rules_python~~python~pythons_hub"
+          ],
+          [
+            "rules_python~~python~pythons_hub",
+            "python_3_10_aarch64-apple-darwin",
+            "rules_python~~python~python_3_10_aarch64-apple-darwin"
+          ],
+          [
+            "rules_python~~python~pythons_hub",
+            "python_3_10_host",
+            "rules_python~~python~python_3_10_host"
+          ],
+          [
+            "rules_python~~python~pythons_hub",
+            "python_3_11_aarch64-apple-darwin",
+            "rules_python~~python~python_3_11_aarch64-apple-darwin"
+          ],
+          [
+            "rules_python~~python~pythons_hub",
+            "python_3_11_host",
+            "rules_python~~python~python_3_11_host"
+          ],
+          [
+            "rules_python~~python~pythons_hub",
+            "python_3_12_aarch64-apple-darwin",
+            "rules_python~~python~python_3_12_aarch64-apple-darwin"
+          ],
+          [
+            "rules_python~~python~pythons_hub",
+            "python_3_12_host",
+            "rules_python~~python~python_3_12_host"
+          ],
+          [
+            "rules_python~~python~pythons_hub",
+            "python_3_8_aarch64-apple-darwin",
+            "rules_python~~python~python_3_8_aarch64-apple-darwin"
+          ],
+          [
+            "rules_python~~python~pythons_hub",
+            "python_3_8_host",
+            "rules_python~~python~python_3_8_host"
+          ],
+          [
+            "rules_python~~python~pythons_hub",
+            "python_3_9_aarch64-apple-darwin",
+            "rules_python~~python~python_3_9_aarch64-apple-darwin"
+          ],
+          [
+            "rules_python~~python~pythons_hub",
+            "python_3_9_host",
+            "rules_python~~python~python_3_9_host"
           ]
         ]
       }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ Usage of bazel-bin/target-determinator/target-determinator_/target-determinator:
 
 This binary lists targets to stdout, one-per-line, which were affected between <before-revision> and the currently checked-out revision.
 
+## hash-persister and hash-differ binaries
+
+Target Determinator now includes hash persistence capabilities for optimized CI workflows:
+
+- **hash-persister**: Computes and saves target hashes for a specific git commit to a JSON file, enabling efficient comparison without recomputing hashes later.
+- **hash-differ**: Compares two persisted hash files to identify changed, added, or removed targets between commits, supporting multiple output formats (JSON, target list, summary).
+
+These tools enable faster target determination in CI by pre-computing hashes once per commit and reusing them across multiple comparisons.
+
 ## driver binary
 
 `driver` is a binary which implements a simple CI pipeline; it runs the same logic as `target-determinator`, then tests all identified targets.

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -83,6 +83,7 @@ type CommonFlags struct {
 	FilterIncompatibleTargets              bool
 	CacheDirectory                         *string
 	NoCacheResults                         bool
+	QueryBackend                           *string
 }
 
 func StrPtr() *string {
@@ -107,6 +108,7 @@ func RegisterCommonFlags() *CommonFlags {
 		FilterIncompatibleTargets:              true,
 		CacheDirectory:                         StrPtr(),
 		NoCacheResults:                         false,
+		QueryBackend:                           StrPtr(),
 	}
 	flag.BoolVar(&commonFlags.Version, "version", false, "Print the version of the tool and exit.")
 	flag.StringVar(commonFlags.WorkingDirectory, "working-directory", ".", "Working directory to query.")
@@ -129,6 +131,7 @@ func RegisterCommonFlags() *CommonFlags {
 	flag.BoolVar(&commonFlags.FilterIncompatibleTargets, "filter-incompatible-targets", true, "Whether to filter out incompatible targets from the candidate set of affected targets.")
 	flag.StringVar(commonFlags.CacheDirectory, "cache-dir", defaultCacheDir(), "Cache directory to avoid existing re-computations. Note: home- and system- bazelrc files, environment variables, and host hardware/OS are not included in the results cache key. Use --nocache_results if necessary.")
 	flag.BoolVar(&commonFlags.NoCacheResults, "nocache_results", false, "Disable loading and saving of results to the cache.")
+	flag.StringVar(commonFlags.QueryBackend, "query-backend", "cquery", "Query backend to use for target discovery. Accepted values: cquery, query. 'query' is faster but less precise (no configuration resolution, no select() resolution, no incompatible target filtering).")
 	return &commonFlags
 }
 
@@ -162,6 +165,11 @@ func ValidateCommonFlags(commandName string, flags *CommonFlags) (targetPattern 
 }
 
 func ResolveCommonConfig(commonFlags *CommonFlags, beforeRevStr string) (*CommonConfig, error) {
+
+	// Flag validation
+	if *commonFlags.QueryBackend == "query" && *commonFlags.AnalysisCacheClearStrategy != "skip" {
+		return nil, fmt.Errorf("--analysis-cache-clear-strategy=%s is incompatible with --query-backend=query: bazel query does not use the analysis cache", *commonFlags.AnalysisCacheClearStrategy)
+	}
 
 	// Context attributes
 
@@ -205,6 +213,7 @@ func ResolveCommonConfig(commonFlags *CommonFlags, beforeRevStr string) (*Common
 		EnforceCleanRepo:                       commonFlags.EnforceCleanRepo == EnforceClean,
 		CacheDirectory:                         *commonFlags.CacheDirectory,
 		NoCacheResults:                         commonFlags.NoCacheResults,
+		QueryBackend:                           *commonFlags.QueryBackend,
 	}
 
 	// Non-context attributes

--- a/hash-differ/BUILD.bazel
+++ b/hash-differ/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//rules:multi_platform_go_binary.bzl", "multi_platform_go_binary")
+
+go_library(
+    name = "hash-differ_lib",
+    srcs = ["hash-differ.go"],
+    importpath = "github.com/bazel-contrib/target-determinator/hash-differ",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//pkg",
+    ],
+)
+
+multi_platform_go_binary(
+    name = "hash-differ",
+    embed = [":hash-differ_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/hash-differ/hash-differ.go
+++ b/hash-differ/hash-differ.go
@@ -1,0 +1,191 @@
+// hash-differ is a binary to compare two persisted hash files and identify differences.
+// This allows for efficient Bazel diff computation without recomputing hashes.
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/bazel-contrib/target-determinator/pkg"
+)
+
+type hashDifferFlags struct {
+	beforeFile   string
+	afterFile    string
+	outputFormat string
+	outputFile   string
+	verbose      bool
+}
+
+func main() {
+	flags, err := parseFlags()
+	if err != nil {
+		fmt.Fprintf(flag.CommandLine.Output(), "Failed to parse flags: %v\n", err)
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
+		fmt.Fprintf(flag.CommandLine.Output(), "  %s <before-hash-file> <after-hash-file>\n", filepath.Base(os.Args[0]))
+		fmt.Fprintf(flag.CommandLine.Output(), "Where:\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  <before-hash-file> is the path to the first hash file\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  <after-hash-file> is the path to the second hash file\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "Optional flags:\n")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	log.Printf("Comparing hash files: %s vs %s", flags.beforeFile, flags.afterFile)
+
+	result, err := pkg.CompareHashFiles(flags.beforeFile, flags.afterFile)
+	if err != nil {
+		log.Fatalf("Failed to compare hash files: %v", err)
+	}
+
+	if flags.verbose {
+		log.Printf("Comparison complete:")
+		log.Printf("  Before commit: %s", result.BeforeCommit)
+		log.Printf("  After commit: %s", result.AfterCommit)
+		log.Printf("  Total differences: %d", len(result.Differences))
+		log.Printf("  Changed targets: %d", result.Summary.TotalChanged)
+		log.Printf("  Added targets: %d", result.Summary.TotalAdded)
+		log.Printf("  Removed targets: %d", result.Summary.TotalRemoved)
+		log.Printf("  Affected target labels: %d", len(result.Summary.AffectedTargets))
+	}
+
+	switch flags.outputFormat {
+	case "json":
+		err = outputJSON(result, flags.outputFile)
+	case "targets":
+		err = outputTargetList(result, flags.outputFile)
+	case "summary":
+		err = outputSummary(result, flags.outputFile)
+	default:
+		err = fmt.Errorf("unsupported output format: %s", flags.outputFormat)
+	}
+
+	if err != nil {
+		log.Fatalf("Failed to output results: %v", err)
+	}
+
+	if flags.outputFile == "" {
+		log.Printf("Results written to stdout")
+	} else {
+		log.Printf("Results written to %s", flags.outputFile)
+	}
+}
+
+func parseFlags() (*hashDifferFlags, error) {
+	var flags hashDifferFlags
+
+	flag.StringVar(&flags.outputFormat, "format", "targets", "Output format: json, targets, or summary")
+	flag.StringVar(&flags.outputFile, "output", "", "Output file (default: stdout)")
+	flag.BoolVar(&flags.verbose, "verbose", false, "Enable verbose logging")
+
+	flag.Parse()
+
+	positional := flag.Args()
+	if len(positional) != 2 {
+		return nil, fmt.Errorf("expected two positional arguments, <before-hash-file> <after-hash-file>, but got %d", len(positional))
+	}
+
+	flags.beforeFile = positional[0]
+	flags.afterFile = positional[1]
+
+	// Validate input files exist
+	if _, err := os.Stat(flags.beforeFile); os.IsNotExist(err) {
+		return nil, fmt.Errorf("before hash file does not exist: %s", flags.beforeFile)
+	}
+	if _, err := os.Stat(flags.afterFile); os.IsNotExist(err) {
+		return nil, fmt.Errorf("after hash file does not exist: %s", flags.afterFile)
+	}
+
+	// Validate output format
+	validFormats := map[string]bool{
+		"json":    true,
+		"targets": true,
+		"summary": true,
+	}
+	if !validFormats[flags.outputFormat] {
+		return nil, fmt.Errorf("invalid output format: %s (valid options: json, targets, summary)", flags.outputFormat)
+	}
+
+	return &flags, nil
+}
+
+func outputJSON(result *pkg.HashComparisonResult, outputFile string) error {
+	var output *os.File
+	var err error
+
+	if outputFile == "" {
+		output = os.Stdout
+	} else {
+		output, err = os.Create(outputFile)
+		if err != nil {
+			return fmt.Errorf("failed to create output file: %w", err)
+		}
+		defer output.Close()
+	}
+
+	encoder := json.NewEncoder(output)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(result)
+}
+
+func outputTargetList(result *pkg.HashComparisonResult, outputFile string) error {
+	var output *os.File
+	var err error
+
+	if outputFile == "" {
+		output = os.Stdout
+	} else {
+		output, err = os.Create(outputFile)
+		if err != nil {
+			return fmt.Errorf("failed to create output file: %w", err)
+		}
+		defer output.Close()
+	}
+
+	// Output one target label per line (compatible with target-determinator output)
+	for _, target := range result.Summary.AffectedTargets {
+		if _, err := fmt.Fprintln(output, target); err != nil {
+			return fmt.Errorf("failed to write target: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func outputSummary(result *pkg.HashComparisonResult, outputFile string) error {
+	var output *os.File
+	var err error
+
+	if outputFile == "" {
+		output = os.Stdout
+	} else {
+		output, err = os.Create(outputFile)
+		if err != nil {
+			return fmt.Errorf("failed to create output file: %w", err)
+		}
+		defer output.Close()
+	}
+
+	fmt.Fprintf(output, "Hash Comparison Summary\n")
+	fmt.Fprintf(output, "======================\n")
+	fmt.Fprintf(output, "Before commit: %s\n", result.BeforeCommit)
+	fmt.Fprintf(output, "After commit:  %s\n", result.AfterCommit)
+	fmt.Fprintf(output, "\n")
+	fmt.Fprintf(output, "Target Changes:\n")
+	fmt.Fprintf(output, "  Changed:     %d\n", result.Summary.TotalChanged)
+	fmt.Fprintf(output, "  Added:       %d\n", result.Summary.TotalAdded)
+	fmt.Fprintf(output, "  Removed:     %d\n", result.Summary.TotalRemoved)
+	fmt.Fprintf(output, "  Total Diff:  %d\n", len(result.Differences))
+	fmt.Fprintf(output, "\n")
+	fmt.Fprintf(output, "Affected Target Labels (%d):\n", len(result.Summary.AffectedTargets))
+	for _, target := range result.Summary.AffectedTargets {
+		fmt.Fprintf(output, "  %s\n", target)
+	}
+
+	return nil
+}

--- a/hash-persister/BUILD.bazel
+++ b/hash-persister/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//rules:multi_platform_go_binary.bzl", "multi_platform_go_binary")
+
+go_library(
+    name = "hash-persister_lib",
+    srcs = ["hash-persister.go"],
+    importpath = "github.com/bazel-contrib/target-determinator/hash-persister",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//cli",
+        "//pkg",
+    ],
+)
+
+multi_platform_go_binary(
+    name = "hash-persister",
+    embed = [":hash-persister_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/hash-persister/hash-persister.go
+++ b/hash-persister/hash-persister.go
@@ -1,0 +1,163 @@
+// hash-persister is a binary to compute and persist target hashes for a given git commit SHA.
+// This allows for later comparison between commits without recomputing hashes.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/bazel-contrib/target-determinator/cli"
+	"github.com/bazel-contrib/target-determinator/pkg"
+)
+
+type hashPersisterFlags struct {
+	commonFlags *cli.CommonFlags
+	commitSha   string
+	outputFile  string
+}
+
+type config struct {
+	Context    *pkg.Context
+	CommitSha  string
+	Targets    pkg.TargetsList
+	OutputFile string
+}
+
+func main() {
+	start := time.Now()
+	defer func() { log.Printf("Finished after %v", time.Since(start)) }()
+
+	flags, err := parseFlags()
+	if err != nil {
+		fmt.Fprintf(flag.CommandLine.Output(), "Failed to parse flags: %v\n", err)
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
+		fmt.Fprintf(flag.CommandLine.Output(), "  %s <git-commit-sha>\n", filepath.Base(os.Args[0]))
+		fmt.Fprintf(flag.CommandLine.Output(), "Where <git-commit-sha> is the commit SHA to compute and persist hashes for.\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "Optional flags:\n")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	config, err := resolveConfig(*flags)
+	if err != nil {
+		fmt.Println("Hash Persister invocation Error")
+		log.Fatalf("Error during preprocessing: %v", err)
+	}
+
+	// Create LabelledGitRev for the specified commit
+	commitRev, err := pkg.NewLabelledGitRev(config.Context.WorkspacePath, config.CommitSha, "commit")
+	if err != nil {
+		log.Fatalf("Failed to resolve commit %s: %v", config.CommitSha, err)
+	}
+
+	log.Printf("Computing hashes for commit %s", config.CommitSha)
+
+	// Process the commit to get query results with computed hashes
+	queryResults, cleanup, err := pkg.LoadIncompleteMetadata(config.Context, commitRev, config.Targets)
+	defer cleanup()
+	if err != nil {
+		log.Fatalf("Failed to load metadata for commit %s: %v", config.CommitSha, err)
+	}
+
+	log.Println("Computing target hashes")
+	if err := queryResults.PrefillCache(); err != nil {
+		log.Fatalf("Failed to compute hashes for commit %s: %v", config.CommitSha, err)
+	}
+
+	log.Printf("Persisting hashes to %s", config.OutputFile)
+	if err := pkg.PersistHashes(config.OutputFile, config.CommitSha, queryResults, config.Context, config.Targets.String()); err != nil {
+		log.Fatalf("Failed to persist hashes: %v", err)
+	}
+
+	log.Printf("Successfully persisted hashes for %d targets to %s",
+		len(queryResults.MatchingTargets.Labels()), config.OutputFile)
+}
+
+func parseFlags() (*hashPersisterFlags, error) {
+	var flags hashPersisterFlags
+	flags.commonFlags = cli.RegisterCommonFlags()
+	flag.StringVar(&flags.outputFile, "output", "", "Output file path for persisted hashes (required)")
+
+	flag.Parse()
+
+	if flags.outputFile == "" {
+		return nil, fmt.Errorf("output file is required")
+	}
+
+	positional := flag.Args()
+	if len(positional) != 1 {
+		return nil, fmt.Errorf("expected one positional argument, <git-commit-sha>, but got %d", len(positional))
+	}
+	flags.commitSha = positional[0]
+
+	return &flags, nil
+}
+
+func resolveConfig(flags hashPersisterFlags) (*config, error) {
+	// Validate working directory
+	workingDirectory, err := filepath.Abs(*flags.commonFlags.WorkingDirectory)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get working directory from %v: %w", *flags.commonFlags.WorkingDirectory, err)
+	}
+
+	// Get current revision to restore later
+	currentBranch, err := pkg.GitRevParse(workingDirectory, "HEAD", true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current git revision: %w", err)
+	}
+
+	afterRev, err := pkg.NewLabelledGitRev(workingDirectory, currentBranch, "current")
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve the current git revision: %w", err)
+	}
+
+	bazelCmd := pkg.DefaultBazelCmd{
+		BazelPath:        *flags.commonFlags.BazelPath,
+		BazelStartupOpts: *flags.commonFlags.BazelStartupOpts,
+		BazelOpts:        *flags.commonFlags.BazelOpts,
+	}
+
+	outputBase, err := pkg.BazelOutputBase(workingDirectory, bazelCmd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve the bazel output base: %w", err)
+	}
+
+	context := &pkg.Context{
+		WorkspacePath:                          workingDirectory,
+		OriginalRevision:                       afterRev,
+		BazelCmd:                               bazelCmd,
+		BazelOutputBase:                        outputBase,
+		DeleteCachedWorktree:                   flags.commonFlags.DeleteCachedWorktree,
+		IgnoredFiles:                           *flags.commonFlags.IgnoredFiles,
+		BeforeQueryErrorBehavior:               *flags.commonFlags.BeforeQueryErrorBehavior,
+		AnalysisCacheClearStrategy:             *flags.commonFlags.AnalysisCacheClearStrategy,
+		CompareQueriesAroundAnalysisCacheClear: flags.commonFlags.CompareQueriesAroundAnalysisCacheClear,
+		FilterIncompatibleTargets:              flags.commonFlags.FilterIncompatibleTargets,
+		EnforceCleanRepo:                       flags.commonFlags.EnforceCleanRepo == cli.EnforceClean,
+	}
+
+	targetsList, err := pkg.ParseTargetsList(*flags.commonFlags.TargetsFlag)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse targets: %w", err)
+	}
+
+	// Validate output file directory exists
+	outputDir := filepath.Dir(flags.outputFile)
+	if outputDir != "." {
+		if err := os.MkdirAll(outputDir, 0755); err != nil {
+			return nil, fmt.Errorf("failed to create output directory %s: %w", outputDir, err)
+		}
+	}
+
+	return &config{
+		Context:    context,
+		CommitSha:  flags.commitSha,
+		Targets:    targetsList,
+		OutputFile: flags.outputFile,
+	}, nil
+}

--- a/hash-persister/hash-persister.go
+++ b/hash-persister/hash-persister.go
@@ -107,6 +107,10 @@ func parseFlags() (*hashPersisterFlags, error) {
 }
 
 func resolveConfig(flags hashPersisterFlags) (*config, error) {
+	if *flags.commonFlags.QueryBackend == "query" && *flags.commonFlags.AnalysisCacheClearStrategy != "skip" {
+		return nil, fmt.Errorf("--analysis-cache-clear-strategy=%s is incompatible with --query-backend=query: bazel query does not use the analysis cache", *flags.commonFlags.AnalysisCacheClearStrategy)
+	}
+
 	// Validate working directory
 	workingDirectory, err := filepath.Abs(*flags.commonFlags.WorkingDirectory)
 	if err != nil {
@@ -147,6 +151,7 @@ func resolveConfig(flags hashPersisterFlags) (*config, error) {
 		CompareQueriesAroundAnalysisCacheClear: flags.commonFlags.CompareQueriesAroundAnalysisCacheClear,
 		FilterIncompatibleTargets:              flags.commonFlags.FilterIncompatibleTargets,
 		EnforceCleanRepo:                       flags.commonFlags.EnforceCleanRepo == cli.EnforceClean,
+		QueryBackend:                           *flags.commonFlags.QueryBackend,
 	}
 
 	targetsList, err := pkg.ParseTargetsList(*flags.commonFlags.TargetsFlag)

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "hash_cache_test.go",
         "normalizer_test.go",
         "target_determinator_test.go",
+        "walker_test.go",
     ],
     data = ["//testdata/HelloWorld:all_srcs"],
     embed = [":pkg"],

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "cache.go",
         "configurations.go",
         "hash_cache.go",
+        "hash_persistence.go",
         "normalizer.go",
         "target_determinator.go",
         "targets_list.go",

--- a/pkg/cache.go
+++ b/pkg/cache.go
@@ -111,6 +111,7 @@ func collectCacheContextFields(ctx *Context) map[string]interface{} {
 		"BazelCmd":                  ctx.BazelCmd.HashKey(),
 		"IgnoredFiles":              ignoredFiles,
 		"FilterIncompatibleTargets": ctx.FilterIncompatibleTargets,
+		"QueryBackend":              ctx.QueryBackend,
 	}
 }
 
@@ -174,7 +175,7 @@ func LoadFromCache(context *Context, treeSHA string, targetPattern string) (*Que
 	queryResults := &QueryResults{
 		MatchingTargets:             matchingTargets,
 		TransitiveConfiguredTargets: nil,
-		TargetHashCache:             NewTargetHashCache(nil, &normalizer, serialized.BazelRelease),
+		TargetHashCache:             NewTargetHashCache(nil, &normalizer, serialized.BazelRelease, false),
 		BazelRelease:                serialized.BazelRelease,
 	}
 

--- a/pkg/cache_test.go
+++ b/pkg/cache_test.go
@@ -93,7 +93,7 @@ func TestSaveToCacheLoadFromCache(t *testing.T) {
 	qr := &QueryResults{
 		MatchingTargets: mt,
 		BazelRelease:    bazelRelease,
-		TargetHashCache: NewTargetHashCache(nil, &Normalizer{}, bazelRelease),
+		TargetHashCache: NewTargetHashCache(nil, &Normalizer{}, bazelRelease, false),
 	}
 
 	if err := SaveToCache(ctx, "deadcafe", "//...", qr); err != nil {

--- a/pkg/hash_cache.go
+++ b/pkg/hash_cache.go
@@ -25,12 +25,18 @@ import (
 )
 
 // NewTargetHashCache creates a TargetHashCache which uses context for metadata lookups.
+// When forceDisableConfiguredRuleInputs is true, ConfiguredRuleInput will not be used regardless
+// of Bazel version. This is needed for the query backend which doesn't populate ConfiguredRuleInput.
 func NewTargetHashCache(
 	context map[gazelle_label.Label]map[Configuration]*analysis.ConfiguredTarget,
 	normalizer *Normalizer,
 	bazelRelease string,
+	forceDisableConfiguredRuleInputs bool,
 ) *TargetHashCache {
 	bazelVersionSupportsConfiguredRuleInputs := isConfiguredRuleInputsSupported(bazelRelease)
+	if forceDisableConfiguredRuleInputs {
+		bazelVersionSupportsConfiguredRuleInputs = false
+	}
 
 	return &TargetHashCache{
 		context: context,
@@ -565,7 +571,15 @@ func hashRule(thc *TargetHashCache, rule *build.Rule, configuration *analysis.Co
 	// rather than hashing attributes ourselves.
 	// On the plus side, this builds in some heuristics from Bazel (e.g. ignoring `generator_location`).
 	// On the down side, it would even further decouple our "hashing" and "diffing" procedures.
-	for _, attr := range rule.GetAttribute() {
+	//
+	// Sort attributes by name before hashing to ensure deterministic output regardless of the
+	// order Bazel returns them in the proto output, which can vary between invocations.
+	sortedAttributes := make([]*build.Attribute, len(rule.GetAttribute()))
+	copy(sortedAttributes, rule.GetAttribute())
+	sort.Slice(sortedAttributes, func(i, j int) bool {
+		return sortedAttributes[i].GetName() < sortedAttributes[j].GetName()
+	})
+	for _, attr := range sortedAttributes {
 		normalizedAttribute := thc.AttributeForSerialization(attr)
 
 		protoBytes, err := proto.Marshal(normalizedAttribute)
@@ -583,6 +597,25 @@ func hashRule(thc *TargetHashCache, rule *build.Rule, configuration *analysis.Co
 	if err != nil {
 		return nil, err
 	}
+	// Sort rule inputs by label (and configuration as tiebreaker) to ensure deterministic output
+	// regardless of the order Bazel returns them in the proto output, which can vary between
+	// invocations. The configuration tiebreaker is needed because the ConfiguredRuleInput path
+	// can produce multiple entries for the same label with different configurations.
+	sort.Slice(labelsAndConfigurations, func(i, j int) bool {
+		li, lj := labelsAndConfigurations[i].Label.String(), labelsAndConfigurations[j].Label.String()
+		if li != lj {
+			return li < lj
+		}
+		// Tiebreak by first configuration (each ConfiguredRuleInput entry has exactly one).
+		ci, cj := "", ""
+		if len(labelsAndConfigurations[i].Configurations) > 0 {
+			ci = labelsAndConfigurations[i].Configurations[0].String()
+		}
+		if len(labelsAndConfigurations[j].Configurations) > 0 {
+			cj = labelsAndConfigurations[j].Configurations[0].String()
+		}
+		return ci < cj
+	})
 	for _, ruleInputLabelAndConfigurations := range labelsAndConfigurations {
 		for _, ruleInputConfiguration := range ruleInputLabelAndConfigurations.Configurations {
 			ruleInputLabel := ruleInputLabelAndConfigurations.Label

--- a/pkg/hash_cache_test.go
+++ b/pkg/hash_cache_test.go
@@ -385,7 +385,7 @@ func parseResult(t *testing.T, result *analysis.CqueryResult, bazelRelease strin
 	if err != nil {
 		t.Fatalf("Failed to parse cquery result: %v", err)
 	}
-	return NewTargetHashCache(cqueryResult, &n, bazelRelease)
+	return NewTargetHashCache(cqueryResult, &n, bazelRelease, false)
 }
 
 func areHashesEqual(left, right []byte) bool {

--- a/pkg/hash_persistence.go
+++ b/pkg/hash_persistence.go
@@ -1,0 +1,277 @@
+package pkg
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	gazelle_label "github.com/bazelbuild/bazel-gazelle/label"
+)
+
+// PersistedHashData represents the structure of a persisted hash file
+type PersistedHashData struct {
+	// GitCommitSha is the git commit SHA this hash data was computed for
+	GitCommitSha string `json:"git_commit_sha"`
+	// Timestamp when the hash was computed
+	Timestamp time.Time `json:"timestamp"`
+	// BazelRelease version used for computing hashes
+	BazelRelease string `json:"bazel_release"`
+	// TargetHashes maps target labels to their configurations and hashes
+	TargetHashes map[string]map[string]string `json:"target_hashes"`
+	// Metadata contains additional information about the computation
+	Metadata HashMetadata `json:"metadata"`
+}
+
+// HashMetadata contains metadata about the hash computation
+type HashMetadata struct {
+	// TargetsPattern is the target pattern used (e.g., "//...")
+	TargetsPattern string `json:"targets_pattern"`
+	// WorkspacePath is the absolute path to the workspace
+	WorkspacePath string `json:"workspace_path"`
+	// TotalTargets is the number of targets for which hashes were computed
+	TotalTargets int `json:"total_targets"`
+}
+
+// PersistHashes saves the computed hashes to a JSON file
+func PersistHashes(filePath string, gitCommitSha string, queryResults *QueryResults, context *Context, targetsPattern string) error {
+	targetHashes := make(map[string]map[string]string)
+	totalTargets := 0
+
+	// Extract hashes from QueryResults
+	for _, label := range queryResults.MatchingTargets.Labels() {
+		configurations := queryResults.MatchingTargets.ConfigurationsFor(label)
+		labelStr := label.String()
+		targetHashes[labelStr] = make(map[string]string)
+
+		for _, config := range configurations {
+			hash, err := queryResults.TargetHashCache.Hash(LabelAndConfiguration{
+				Label:         label,
+				Configuration: config,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to get hash for target %s with configuration %s: %w", labelStr, config, err)
+			}
+			targetHashes[labelStr][config.String()] = hex.EncodeToString(hash)
+			totalTargets++
+		}
+	}
+
+	persistedData := PersistedHashData{
+		GitCommitSha: gitCommitSha,
+		Timestamp:    time.Now(),
+		BazelRelease: queryResults.BazelRelease,
+		TargetHashes: targetHashes,
+		Metadata: HashMetadata{
+			TargetsPattern: targetsPattern,
+			WorkspacePath:  context.WorkspacePath,
+			TotalTargets:   totalTargets,
+		},
+	}
+
+	file, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to create hash file %s: %w", filePath, err)
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(persistedData); err != nil {
+		return fmt.Errorf("failed to encode hash data to %s: %w", filePath, err)
+	}
+
+	return nil
+}
+
+// LoadPersistedHashes loads persisted hash data from a JSON file
+func LoadPersistedHashes(filePath string) (*PersistedHashData, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open hash file %s: %w", filePath, err)
+	}
+	defer file.Close()
+
+	var persistedData PersistedHashData
+	decoder := json.NewDecoder(file)
+	if err := decoder.Decode(&persistedData); err != nil {
+		return nil, fmt.Errorf("failed to decode hash data from %s: %w", filePath, err)
+	}
+
+	return &persistedData, nil
+}
+
+// HashDiff represents a difference between two hash files
+type HashDiff struct {
+	// Label is the target label
+	Label string `json:"label"`
+	// Configuration is the configuration checksum
+	Configuration string `json:"configuration"`
+	// Status indicates the type of change: "added", "removed", "changed"
+	Status string `json:"status"`
+	// BeforeHash is the hash in the before file (empty for added targets)
+	BeforeHash string `json:"before_hash,omitempty"`
+	// AfterHash is the hash in the after file (empty for removed targets)
+	AfterHash string `json:"after_hash,omitempty"`
+}
+
+// HashComparisonResult contains the results of comparing two hash files
+type HashComparisonResult struct {
+	// BeforeCommit is the git commit SHA of the before hash file
+	BeforeCommit string `json:"before_commit"`
+	// AfterCommit is the git commit SHA of the after hash file
+	AfterCommit string `json:"after_commit"`
+	// Differences is a list of all target differences
+	Differences []HashDiff `json:"differences"`
+	// Summary contains aggregate statistics
+	Summary HashComparisonSummary `json:"summary"`
+}
+
+// HashComparisonSummary contains summary statistics of the comparison
+type HashComparisonSummary struct {
+	// TotalChanged is the number of targets that changed
+	TotalChanged int `json:"total_changed"`
+	// TotalAdded is the number of targets that were added
+	TotalAdded int `json:"total_added"`
+	// TotalRemoved is the number of targets that were removed
+	TotalRemoved int `json:"total_removed"`
+	// AffectedTargets is a sorted list of unique target labels that were affected
+	AffectedTargets []string `json:"affected_targets"`
+}
+
+// CompareHashFiles compares two persisted hash files and returns the differences
+func CompareHashFiles(beforeFile, afterFile string) (*HashComparisonResult, error) {
+	beforeData, err := LoadPersistedHashes(beforeFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load before hash file: %w", err)
+	}
+
+	afterData, err := LoadPersistedHashes(afterFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load after hash file: %w", err)
+	}
+
+	var differences []HashDiff
+	affectedTargetsSet := make(map[string]bool)
+
+	// Check for changed and removed targets
+	for label, beforeConfigs := range beforeData.TargetHashes {
+		afterConfigs, exists := afterData.TargetHashes[label]
+		if !exists {
+			// Target was removed entirely
+			for config, beforeHash := range beforeConfigs {
+				differences = append(differences, HashDiff{
+					Label:         label,
+					Configuration: config,
+					Status:        "removed",
+					BeforeHash:    beforeHash,
+				})
+				affectedTargetsSet[label] = true
+			}
+			continue
+		}
+
+		// Check each configuration of the target
+		for config, beforeHash := range beforeConfigs {
+			afterHash, configExists := afterConfigs[config]
+			if !configExists {
+				// Configuration was removed
+				differences = append(differences, HashDiff{
+					Label:         label,
+					Configuration: config,
+					Status:        "removed",
+					BeforeHash:    beforeHash,
+				})
+				affectedTargetsSet[label] = true
+			} else if beforeHash != afterHash {
+				// Hash changed
+				differences = append(differences, HashDiff{
+					Label:         label,
+					Configuration: config,
+					Status:        "changed",
+					BeforeHash:    beforeHash,
+					AfterHash:     afterHash,
+				})
+				affectedTargetsSet[label] = true
+			}
+		}
+
+		// Check for added configurations in existing targets
+		for config, afterHash := range afterConfigs {
+			if _, configExists := beforeConfigs[config]; !configExists {
+				differences = append(differences, HashDiff{
+					Label:         label,
+					Configuration: config,
+					Status:        "added",
+					AfterHash:     afterHash,
+				})
+				affectedTargetsSet[label] = true
+			}
+		}
+	}
+
+	// Check for entirely new targets
+	for label, afterConfigs := range afterData.TargetHashes {
+		if _, exists := beforeData.TargetHashes[label]; !exists {
+			for config, afterHash := range afterConfigs {
+				differences = append(differences, HashDiff{
+					Label:         label,
+					Configuration: config,
+					Status:        "added",
+					AfterHash:     afterHash,
+				})
+				affectedTargetsSet[label] = true
+			}
+		}
+	}
+
+	// Convert affected targets set to sorted slice
+	var affectedTargets []string
+	for label := range affectedTargetsSet {
+		affectedTargets = append(affectedTargets, label)
+	}
+	sort.Strings(affectedTargets)
+
+	// Calculate summary statistics
+	summary := HashComparisonSummary{
+		AffectedTargets: affectedTargets,
+	}
+	for _, diff := range differences {
+		switch diff.Status {
+		case "added":
+			summary.TotalAdded++
+		case "removed":
+			summary.TotalRemoved++
+		case "changed":
+			summary.TotalChanged++
+		}
+	}
+
+	return &HashComparisonResult{
+		BeforeCommit: beforeData.GitCommitSha,
+		AfterCommit:  afterData.GitCommitSha,
+		Differences:  differences,
+		Summary:      summary,
+	}, nil
+}
+
+// GetAffectedTargetLabels returns a list of unique target labels that are affected
+func (result *HashComparisonResult) GetAffectedTargetLabels() ([]gazelle_label.Label, error) {
+	var labels []gazelle_label.Label
+	seenLabels := make(map[string]bool)
+
+	for _, diff := range result.Differences {
+		if !seenLabels[diff.Label] {
+			label, err := gazelle_label.Parse(diff.Label)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse label %s: %w", diff.Label, err)
+			}
+			labels = append(labels, label)
+			seenLabels[diff.Label] = true
+		}
+	}
+
+	return labels, nil
+}

--- a/pkg/hash_persistence.go
+++ b/pkg/hash_persistence.go
@@ -139,6 +139,8 @@ type HashComparisonSummary struct {
 	TotalRemoved int `json:"total_removed"`
 	// AffectedTargets is a sorted list of unique target labels that were affected
 	AffectedTargets []string `json:"affected_targets"`
+	// AfterTargets is a set of target labels that exist in after data
+	AfterTargets map[string]bool `json:"after_targets"`
 }
 
 // CompareHashFiles compares two persisted hash files and returns the differences
@@ -234,9 +236,15 @@ func CompareHashFiles(beforeFile, afterFile string) (*HashComparisonResult, erro
 	}
 	sort.Strings(affectedTargets)
 
+	afterTargetsSet := make(map[string]bool, len(afterData.TargetHashes))
+	for label := range afterData.TargetHashes {
+		afterTargetsSet[label] = true
+	}
+
 	// Calculate summary statistics
 	summary := HashComparisonSummary{
 		AffectedTargets: affectedTargets,
+		AfterTargets:    afterTargetsSet,
 	}
 	for _, diff := range differences {
 		switch diff.Status {

--- a/pkg/hash_persistence.go
+++ b/pkg/hash_persistence.go
@@ -145,15 +145,38 @@ type HashComparisonSummary struct {
 
 // CompareHashFiles compares two persisted hash files and returns the differences
 func CompareHashFiles(beforeFile, afterFile string) (*HashComparisonResult, error) {
-	beforeData, err := LoadPersistedHashes(beforeFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load before hash file: %w", err)
+	// Load files in parallel
+	type loadResult struct {
+		data *PersistedHashData
+		err  error
 	}
 
-	afterData, err := LoadPersistedHashes(afterFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load after hash file: %w", err)
+	beforeChan := make(chan loadResult, 1)
+	afterChan := make(chan loadResult, 1)
+
+	go func() {
+		data, err := LoadPersistedHashes(beforeFile)
+		beforeChan <- loadResult{data: data, err: err}
+	}()
+
+	go func() {
+		data, err := LoadPersistedHashes(afterFile)
+		afterChan <- loadResult{data: data, err: err}
+	}()
+
+	beforeResult := <-beforeChan
+	afterResult := <-afterChan
+
+	if beforeResult.err != nil {
+		return nil, fmt.Errorf("failed to load before hash file: %w", beforeResult.err)
 	}
+
+	if afterResult.err != nil {
+		return nil, fmt.Errorf("failed to load after hash file: %w", afterResult.err)
+	}
+
+	beforeData := beforeResult.data
+	afterData := afterResult.data
 
 	var differences []HashDiff
 	affectedTargetsSet := make(map[string]bool)

--- a/pkg/target_determinator.go
+++ b/pkg/target_determinator.go
@@ -805,16 +805,10 @@ func doQueryDeps(context *Context, targets TargetsList) (*QueryResults, error) {
 		}, retErr
 	}
 
-	type parseResult struct {
-		transitiveConfiguredTargets map[label.Label]map[Configuration]*analysis.ConfiguredTarget
-		err                         error
+	transitiveConfiguredTargets, err := ParseCqueryResult(transitiveResult, &normalizer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse cquery result: %w", err)
 	}
-	parseResultCh := make(chan parseResult, 1)
-	go func() {
-		log.Println("Parsing transitive result")
-		transitiveConfiguredTargets, err := ParseCqueryResult(transitiveResult, &normalizer)
-		parseResultCh <- parseResult{transitiveConfiguredTargets, err}
-	}()
 
 	matchingTargetResults, err := runToCqueryResult(context, targets.String(), false, bazelRelease)
 	if err != nil {
@@ -865,12 +859,6 @@ func doQueryDeps(context *Context, targets TargetsList) (*QueryResults, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to interpret configurations output: %w", err)
 	}
-
-	parseRes := <-parseResultCh
-	if parseRes.err != nil {
-		return nil, fmt.Errorf("failed to parse cquery result: %w", parseRes.err)
-	}
-	transitiveConfiguredTargets := parseRes.transitiveConfiguredTargets
 
 	queryResults := &QueryResults{
 		MatchingTargets:             matchingTargets,

--- a/pkg/target_determinator.go
+++ b/pkg/target_determinator.go
@@ -147,6 +147,10 @@ type Context struct {
 	IncludeDifferences bool `results_cache_key_ignore:"true"`
 	// NoCacheResults disables both loading results from and saving results to the cache.
 	NoCacheResults bool `results_cache_key_ignore:"true"`
+	// QueryBackend controls which Bazel query backend to use: "cquery" (default) or "query".
+	// "query" operates at the loading phase and is faster but less precise: no configuration
+	// information, no select() resolution, no incompatible target filtering.
+	QueryBackend string
 }
 
 // FullyProcess returns the before and after metadata maps, with fully filled caches.
@@ -274,6 +278,7 @@ func LoadIncompleteMetadata(context *Context, rev LabelledGitRev, targets Target
 		CacheDirectory:                         context.CacheDirectory,
 		IncludeDifferences:                     context.IncludeDifferences,
 		NoCacheResults:                         context.NoCacheResults,
+		QueryBackend:                           context.QueryBackend,
 	}
 	cleanupFunc := func() {}
 
@@ -298,33 +303,43 @@ func LoadIncompleteMetadata(context *Context, rev LabelledGitRev, targets Target
 		}
 	}
 
-	var queryInfoBeforeClear *QueryResults
-	if context.CompareQueriesAroundAnalysisCacheClear {
-		var err error
-		queryInfoBeforeClear, err = doQueryDeps(context, targets)
-		if err != nil {
-			return queryInfoBeforeClear, cleanupFunc, fmt.Errorf("failed to query[before] at %s in %v: %w", rev, context.WorkspacePath, err)
+	// query mode doesn't use the analysis cache, so skip clearing and comparison logic.
+	if context.QueryBackend != "query" {
+		var queryInfoBeforeClear *QueryResults
+		if context.CompareQueriesAroundAnalysisCacheClear {
+			var err error
+			queryInfoBeforeClear, err = doQueryDeps(context, targets)
+			if err != nil {
+				return queryInfoBeforeClear, cleanupFunc, fmt.Errorf("failed to query[before] at %s in %v: %w", rev, context.WorkspacePath, err)
+			}
 		}
-	}
 
-	// Clear analysis cache before each query, as cquery configurations leak across invocations.
-	// See https://github.com/bazelbuild/bazel/issues/14725
-	if err := clearAnalysisCache(context); err != nil {
-		return nil, cleanupFunc, err
+		// Clear analysis cache before each query, as cquery configurations leak across invocations.
+		// See https://github.com/bazelbuild/bazel/issues/14725
+		if err := clearAnalysisCache(context); err != nil {
+			return nil, cleanupFunc, err
+		}
+
+		queryInfo, err := doQueryDeps(context, targets)
+		if err != nil {
+			return queryInfo, cleanupFunc, fmt.Errorf("failed to query at %s in %v: %w", rev, context.WorkspacePath, err)
+		}
+
+		if context.CompareQueriesAroundAnalysisCacheClear {
+			if !reflect.DeepEqual(queryInfoBeforeClear.MatchingTargets, queryInfo.MatchingTargets) {
+				return nil, cleanupFunc, fmt.Errorf("inconsistent cquery results before and after analysis cache clear: MatchingTargets")
+			}
+			if !reflect.DeepEqual(queryInfoBeforeClear.TransitiveConfiguredTargets, queryInfo.TransitiveConfiguredTargets) {
+				return nil, cleanupFunc, fmt.Errorf("inconsistent cquery results before and after analysis cache clear: TransitiveConfiguredTargets")
+			}
+		}
+
+		return queryInfo, cleanupFunc, nil
 	}
 
 	queryInfo, err := doQueryDeps(context, targets)
 	if err != nil {
 		return queryInfo, cleanupFunc, fmt.Errorf("failed to query at %s in %v: %w", rev, context.WorkspacePath, err)
-	}
-
-	if context.CompareQueriesAroundAnalysisCacheClear {
-		if !reflect.DeepEqual(queryInfoBeforeClear.MatchingTargets, queryInfo.MatchingTargets) {
-			return nil, cleanupFunc, fmt.Errorf("inconsistent cquery results before and after analysis cache clear: MatchingTargets")
-		}
-		if !reflect.DeepEqual(queryInfoBeforeClear.TransitiveConfiguredTargets, queryInfo.TransitiveConfiguredTargets) {
-			return nil, cleanupFunc, fmt.Errorf("inconsistent cquery results before and after analysis cache clear: TransitiveConfiguredTargets")
-		}
 	}
 
 	return queryInfo, cleanupFunc, nil
@@ -771,6 +786,10 @@ func doQueryDeps(context *Context, targets TargetsList) (*QueryResults, error) {
 
 	normalizer := Normalizer{repoMapping}
 
+	if context.QueryBackend == "query" {
+		return doQueryDepsQueryMode(context, targets, &normalizer, bazelRelease)
+	}
+
 	// Work around https://github.com/bazelbuild/bazel/issues/21010
 	var incompatibleTargetsToFilter map[label.Label]bool
 	hasIncompatibleTargetsBug, explanation := versions.ReleaseIsInRange(bazelRelease, version.Must(version.NewVersion("7.0.0-pre.20230628.2")), version.Must(version.NewVersion("7.4.0")))
@@ -799,7 +818,7 @@ func doQueryDeps(context *Context, targets TargetsList) (*QueryResults, error) {
 				labelsToConfigurations: nil,
 			},
 			TransitiveConfiguredTargets: nil,
-			TargetHashCache:             NewTargetHashCache(nil, &normalizer, bazelRelease),
+			TargetHashCache:             NewTargetHashCache(nil, &normalizer, bazelRelease, false),
 			BazelRelease:                bazelRelease,
 			QueryError:                  retErr,
 		}, retErr
@@ -863,10 +882,70 @@ func doQueryDeps(context *Context, targets TargetsList) (*QueryResults, error) {
 	queryResults := &QueryResults{
 		MatchingTargets:             matchingTargets,
 		TransitiveConfiguredTargets: transitiveConfiguredTargets,
-		TargetHashCache:             NewTargetHashCache(transitiveConfiguredTargets, &normalizer, bazelRelease),
+		TargetHashCache:             NewTargetHashCache(transitiveConfiguredTargets, &normalizer, bazelRelease, false),
 		BazelRelease:                bazelRelease,
 		QueryError:                  nil,
 		configurations:              configurations,
+	}
+	return queryResults, nil
+}
+
+func doQueryDepsQueryMode(context *Context, targets TargetsList, normalizer *Normalizer, bazelRelease string) (*QueryResults, error) {
+	depsPattern := fmt.Sprintf("deps(%s)", targets.String())
+	transitiveResult, err := runToQueryResult(context, depsPattern)
+	if err != nil {
+		retErr := fmt.Errorf("failed to query %v: %w", depsPattern, err)
+		return &QueryResults{
+			MatchingTargets: &MatchingTargets{
+				labels:                 nil,
+				labelsToConfigurations: nil,
+			},
+			TransitiveConfiguredTargets: nil,
+			TargetHashCache:             NewTargetHashCache(nil, normalizer, bazelRelease, true),
+			BazelRelease:                bazelRelease,
+			QueryError:                  retErr,
+		}, retErr
+	}
+
+	transitiveConfiguredTargets, err := ParseCqueryResult(transitiveResult, normalizer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse query result: %w", err)
+	}
+
+	// Use --output=label for matching targets since we only need label names here.
+	// The full proto data is already available in the transitive deps result above.
+	matchingLabels, err := runToQueryLabels(context, targets.String(), normalizer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to run top-level query: %w", err)
+	}
+
+	// In query mode, there are no configurations — use a single empty configuration for all targets.
+	emptyConfiguration := NormalizeConfiguration("")
+	log.Println("Matching labels to configurations")
+	labels := make([]label.Label, 0, len(matchingLabels))
+	labelsToConfigurations := make(map[label.Label][]Configuration)
+	for _, l := range matchingLabels {
+		labels = append(labels, l)
+		labelsToConfigurations[l] = append(labelsToConfigurations[l], emptyConfiguration)
+	}
+
+	processedLabelsToConfigurations := make(map[label.Label]*ss.SortedSet[Configuration], len(labels))
+	for l, configurations := range labelsToConfigurations {
+		processedLabelsToConfigurations[l] = ss.NewSortedSetFn(configurations, ConfigurationLess)
+	}
+
+	matchingTargets := &MatchingTargets{
+		labels:                 ss.NewSortedSetFn(labels, CompareLabels),
+		labelsToConfigurations: processedLabelsToConfigurations,
+	}
+
+	queryResults := &QueryResults{
+		MatchingTargets:             matchingTargets,
+		TransitiveConfiguredTargets: transitiveConfiguredTargets,
+		TargetHashCache:             NewTargetHashCache(transitiveConfiguredTargets, normalizer, bazelRelease, true),
+		BazelRelease:                bazelRelease,
+		QueryError:                  nil,
+		configurations:              map[Configuration]singleConfigurationOutput{},
 	}
 	return queryResults, nil
 }
@@ -928,6 +1007,87 @@ func runToCqueryResult(context *Context, pattern string, includeTransitions bool
 		}
 		return result.GetResults(), nil
 	}
+}
+
+func runToQueryResult(context *Context, pattern string) ([]*analysis.ConfiguredTarget, error) {
+	log.Printf("Running query on %s", pattern)
+
+	queryOutputFile, err := os.CreateTemp("", "target-determinator-query-*.proto")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary file for query output: %w", err)
+	}
+	queryOutput := queryOutputFile.Name()
+	defer os.Remove(queryOutput)
+	if err = queryOutputFile.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close temporary file for query output: %w", err)
+	}
+
+	var stderr bytes.Buffer
+	// Unlike cquery (which only gained streamed_proto and output_file in Bazel 8.2),
+	// bazel query has supported both since well before any Bazel version this tool targets.
+	returnVal, err := context.BazelCmd.Execute(
+		BazelCmdConfig{Dir: context.WorkspacePath, Stderr: &stderr},
+		[]string{"--output_base", context.BazelOutputBase},
+		"query", "--output=streamed_proto", "--order_output=no",
+		"--output_file="+queryOutput, pattern)
+
+	if returnVal != 0 || err != nil {
+		return nil, fmt.Errorf("failed to run query on %s: %w. Stderr:\n%v", pattern, err, stderr.String())
+	}
+
+	queryOutputFile, err = os.Open(queryOutput)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open query output file %s for reading: %w", queryOutput, err)
+	}
+	defer queryOutputFile.Close()
+
+	// Wrap each build.Target in an analysis.ConfiguredTarget with nil configuration.
+	var targets []*analysis.ConfiguredTarget
+	reader := bufio.NewReader(queryOutputFile)
+	unmarshalOpts := protodelim.UnmarshalOptions{MaxSize: -1}
+	for {
+		var target build.Target
+		if err = unmarshalOpts.UnmarshalFrom(reader, &target); err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal streamed query output: %w", err)
+		}
+		targets = append(targets, &analysis.ConfiguredTarget{
+			Target:        &target,
+			Configuration: nil,
+		})
+	}
+	return targets, nil
+}
+
+func runToQueryLabels(context *Context, pattern string, normalizer *Normalizer) ([]label.Label, error) {
+	log.Printf("Running query (labels) on %s", pattern)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	returnVal, err := context.BazelCmd.Execute(
+		BazelCmdConfig{Dir: context.WorkspacePath, Stdout: &stdout, Stderr: &stderr},
+		[]string{"--output_base", context.BazelOutputBase},
+		"query", "--output=label", "--order_output=no", pattern)
+
+	if returnVal != 0 || err != nil {
+		return nil, fmt.Errorf("failed to run query on %s: %w. Stderr:\n%v", pattern, err, stderr.String())
+	}
+
+	var labels []label.Label
+	scanner := bufio.NewScanner(&stdout)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		l, err := normalizer.ParseCanonicalLabel(line)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse label from query output %q: %w", line, err)
+		}
+		labels = append(labels, l)
+	}
+	return labels, nil
 }
 
 func findCompatibleTargets(context *Context, pattern string, compatibility bool, n *Normalizer, bazelRelease string) (map[label.Label]bool, error) {

--- a/pkg/target_determinator.go
+++ b/pkg/target_determinator.go
@@ -805,10 +805,16 @@ func doQueryDeps(context *Context, targets TargetsList) (*QueryResults, error) {
 		}, retErr
 	}
 
-	transitiveConfiguredTargets, err := ParseCqueryResult(transitiveResult, &normalizer)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse cquery result: %w", err)
+	type parseResult struct {
+		transitiveConfiguredTargets map[label.Label]map[Configuration]*analysis.ConfiguredTarget
+		err                         error
 	}
+	parseResultCh := make(chan parseResult, 1)
+	go func() {
+		log.Println("Parsing transitive result")
+		transitiveConfiguredTargets, err := ParseCqueryResult(transitiveResult, &normalizer)
+		parseResultCh <- parseResult{transitiveConfiguredTargets, err}
+	}()
 
 	matchingTargetResults, err := runToCqueryResult(context, targets.String(), false, bazelRelease)
 	if err != nil {
@@ -859,6 +865,12 @@ func doQueryDeps(context *Context, targets TargetsList) (*QueryResults, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to interpret configurations output: %w", err)
 	}
+
+	parseRes := <-parseResultCh
+	if parseRes.err != nil {
+		return nil, fmt.Errorf("failed to parse cquery result: %w", parseRes.err)
+	}
+	transitiveConfiguredTargets := parseRes.transitiveConfiguredTargets
 
 	queryResults := &QueryResults{
 		MatchingTargets:             matchingTargets,

--- a/pkg/walker.go
+++ b/pkg/walker.go
@@ -88,35 +88,29 @@ func DiffSingleLabel(beforeMetadata, afterMetadata *QueryResults, includeDiffere
 			callback(label, differences, configuredTarget)
 			return nil
 		}
-		_, ok := beforeMetadata.TransitiveConfiguredTargets[label][configuration]
-		if !ok {
-			collectDifference(Difference{Category: "NewTarget"})
-			callback(label, differences, configuredTarget)
-			return nil
-		} else {
-			labelAndConfiguration := LabelAndConfiguration{
-				Label:         label,
-				Configuration: configuration,
-			}
-			hashBefore, err := beforeMetadata.TargetHashCache.Hash(labelAndConfiguration)
-			if err != nil {
-				return err
-			}
-			hashAfter, err := afterMetadata.TargetHashCache.Hash(labelAndConfiguration)
-			if err != nil {
-				return err
-			}
-			if bytes.Equal(hashBefore, hashAfter) {
-				continue
-			}
-			if includeDifferences {
-				differences, err = WalkDiffs(beforeMetadata.TargetHashCache, afterMetadata.TargetHashCache, labelAndConfiguration)
-				if err != nil {
-					return err
-				}
-			}
-			callback(label, differences, configuredTarget)
+		labelAndConfiguration := LabelAndConfiguration{
+			Label:         label,
+			Configuration: configuration,
 		}
+
+		hashBefore, err := beforeMetadata.TargetHashCache.Hash(labelAndConfiguration)
+		if err != nil {
+			return err
+		}
+		hashAfter, err := afterMetadata.TargetHashCache.Hash(labelAndConfiguration)
+		if err != nil {
+			return err
+		}
+		if bytes.Equal(hashBefore, hashAfter) {
+			continue
+		}
+		if includeDifferences {
+			differences, err = WalkDiffs(beforeMetadata.TargetHashCache, afterMetadata.TargetHashCache, labelAndConfiguration)
+			if err != nil {
+				return err
+			}
+		}
+		callback(label, differences, configuredTarget)
 	}
 	return nil
 }

--- a/pkg/walker_test.go
+++ b/pkg/walker_test.go
@@ -1,0 +1,57 @@
+package pkg
+
+import (
+	"testing"
+
+	ss "github.com/bazel-contrib/target-determinator/common/sorted_set"
+	"github.com/bazel-contrib/target-determinator/third_party/protobuf/bazel/analysis"
+	gazelle_label "github.com/bazelbuild/bazel-gazelle/label"
+)
+
+func makeMatchingTargets(lbl gazelle_label.Label, config Configuration) *MatchingTargets {
+	return &MatchingTargets{
+		labels: ss.NewSortedSetFn([]gazelle_label.Label{lbl}, CompareLabels),
+		labelsToConfigurations: map[gazelle_label.Label]*ss.SortedSet[Configuration]{
+			lbl: ss.NewSortedSetFn([]Configuration{config}, ConfigurationLess),
+		},
+	}
+}
+
+// TestDiffSingleLabel_NoDifferenceWhenBothFromCache verifies that when both before and after
+// metadata are loaded from cache (TransitiveConfiguredTargets == nil, pre-computed hashes
+// present), DiffSingleLabel does not report any differences for an unchanged target.
+func TestDiffSingleLabel_NoDifferenceWhenBothFromCache(t *testing.T) {
+	const bazelRelease = "release 7.0.0"
+	lbl := mustParseLabel("//foo:bar")
+	config := NormalizeConfiguration("deadcafe")
+
+	mt := makeMatchingTargets(lbl, config)
+	fakeHash := []byte{0xde, 0xad, 0xca, 0xfe}
+	hashKey := lbl.String() + "\x00" + config.String()
+
+	makeFromCache := func() *QueryResults {
+		thc := NewTargetHashCache(nil, &Normalizer{}, bazelRelease)
+		if err := thc.RestoreHashes(map[string][]byte{hashKey: fakeHash}); err != nil {
+			t.Fatalf("RestoreHashes: %v", err)
+		}
+		return &QueryResults{
+			MatchingTargets:             mt,
+			TransitiveConfiguredTargets: nil, // as set by LoadFromCache
+			TargetHashCache:             thc,
+			BazelRelease:                bazelRelease,
+		}
+	}
+
+	beforeMetadata := makeFromCache()
+	afterMetadata := makeFromCache()
+
+	err := DiffSingleLabel(
+		beforeMetadata, afterMetadata, false, lbl,
+		func(_ gazelle_label.Label, diffs []Difference, _ *analysis.ConfiguredTarget) {
+			t.Errorf("callback called for unchanged target (diffs when includeDifferences=false are always nil: %v)", diffs)
+		},
+	)
+	if err != nil {
+		t.Fatalf("DiffSingleLabel returned unexpected error: %v", err)
+	}
+}

--- a/pkg/walker_test.go
+++ b/pkg/walker_test.go
@@ -30,7 +30,7 @@ func TestDiffSingleLabel_NoDifferenceWhenBothFromCache(t *testing.T) {
 	hashKey := lbl.String() + "\x00" + config.String()
 
 	makeFromCache := func() *QueryResults {
-		thc := NewTargetHashCache(nil, &Normalizer{}, bazelRelease)
+		thc := NewTargetHashCache(nil, &Normalizer{}, bazelRelease, false)
 		if err := thc.RestoreHashes(map[string][]byte{hashKey: fakeHash}); err != nil {
 			t.Fatalf("RestoreHashes: %v", err)
 		}


### PR DESCRIPTION
## Summary
- Cherry-picks upstream [bazel-contrib/target-determinator@b4c86d3](https://github.com/bazel-contrib/target-determinator/commit/b4c86d30306645b0a385827abf5c7f9e9def46d8): removes the unreachable `NewTarget` case in the walker and fixes spurious targets being returned on a result-cache hit (cached hashes don't populate the configured-target structs the old codepath was looking for).
- Adapts the new `pkg/walker_test.go` to our fork's `NewTargetHashCache` signature, which takes a trailing `bool` argument not present upstream.

## Test plan
- [x] `bazel build //pkg/...`
- [x] `bazel test //pkg:pkg_test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)