### PR TITLE
Canonicalize target hash inputs

### DIFF
--- a/pkg/hash_cache.go
+++ b/pkg/hash_cache.go
@@ -565,7 +565,7 @@ func hashRule(thc *TargetHashCache, rule *build.Rule, configuration *analysis.Co
 	// rather than hashing attributes ourselves.
 	// On the plus side, this builds in some heuristics from Bazel (e.g. ignoring `generator_location`).
 	// On the down side, it would even further decouple our "hashing" and "diffing" procedures.
-	for _, attr := range rule.GetAttribute() {
+	for _, attr := range sortedAttributesForHashing(rule.GetAttribute()) {
 		normalizedAttribute := thc.AttributeForSerialization(attr)
 
 		protoBytes, err := proto.Marshal(normalizedAttribute)
@@ -598,6 +598,21 @@ func hashRule(thc *TargetHashCache, rule *build.Rule, configuration *analysis.Co
 	}
 
 	return hasher.Sum(nil), nil
+}
+
+func sortedAttributesForHashing(attributes []*build.Attribute) []*build.Attribute {
+	sortedAttributes := append([]*build.Attribute(nil), attributes...)
+	sort.SliceStable(sortedAttributes, func(i, j int) bool {
+		leftName := sortedAttributes[i].GetName()
+		rightName := sortedAttributes[j].GetName()
+		if leftName == rightName {
+			leftBytes, _ := proto.MarshalOptions{Deterministic: true}.Marshal(sortedAttributes[i])
+			rightBytes, _ := proto.MarshalOptions{Deterministic: true}.Marshal(sortedAttributes[j])
+			return bytes.Compare(leftBytes, rightBytes) < 0
+		}
+		return leftName < rightName
+	})
+	return sortedAttributes
 }
 
 func getConfiguredRuleInputs(thc *TargetHashCache, rule *build.Rule, ownConfiguration Configuration) ([]LabelAndConfigurations, error) {
@@ -678,7 +693,43 @@ func getConfiguredRuleInputs(thc *TargetHashCache, rule *build.Rule, ownConfigur
 			labelsAndConfigurations = append(labelsAndConfigurations, labelAndConfigurations)
 		}
 	}
-	return labelsAndConfigurations, nil
+	return canonicalizeRuleInputs(labelsAndConfigurations), nil
+}
+
+func canonicalizeRuleInputs(labelsAndConfigurations []LabelAndConfigurations) []LabelAndConfigurations {
+	labelsToConfigurations := make(map[gazelle_label.Label]map[Configuration]struct{})
+	for _, labelAndConfigurations := range labelsAndConfigurations {
+		if _, ok := labelsToConfigurations[labelAndConfigurations.Label]; !ok {
+			labelsToConfigurations[labelAndConfigurations.Label] = make(map[Configuration]struct{})
+		}
+		for _, configuration := range labelAndConfigurations.Configurations {
+			labelsToConfigurations[labelAndConfigurations.Label][configuration] = struct{}{}
+		}
+	}
+
+	labels := make([]gazelle_label.Label, 0, len(labelsToConfigurations))
+	for lbl := range labelsToConfigurations {
+		labels = append(labels, lbl)
+	}
+	sort.Slice(labels, func(i, j int) bool {
+		return CompareLabels(labels[i], labels[j])
+	})
+
+	canonicalized := make([]LabelAndConfigurations, 0, len(labels))
+	for _, lbl := range labels {
+		configurations := make([]Configuration, 0, len(labelsToConfigurations[lbl]))
+		for configuration := range labelsToConfigurations[lbl] {
+			configurations = append(configurations, configuration)
+		}
+		sort.Slice(configurations, func(i, j int) bool {
+			return ConfigurationLess(configurations[i], configurations[j])
+		})
+		canonicalized = append(canonicalized, LabelAndConfigurations{
+			Label:          lbl,
+			Configurations: configurations,
+		})
+	}
+	return canonicalized
 }
 
 type fileHashCache struct {

--- a/pkg/hash_cache_test.go
+++ b/pkg/hash_cache_test.go
@@ -388,6 +388,47 @@ func parseResult(t *testing.T, result *analysis.CqueryResult, bazelRelease strin
 	return NewTargetHashCache(cqueryResult, &n, bazelRelease)
 }
 
+func TestSortedAttributesForHashing(t *testing.T) {
+	attributes := []*build.Attribute{
+		{Name: proto.String("z_attr")},
+		{Name: proto.String("a_attr")},
+		{Name: proto.String("m_attr")},
+	}
+
+	got := sortedAttributesForHashing(attributes)
+	gotNames := []string{got[0].GetName(), got[1].GetName(), got[2].GetName()}
+	wantNames := []string{"a_attr", "m_attr", "z_attr"}
+	if !reflect.DeepEqual(gotNames, wantNames) {
+		t.Fatalf("sortedAttributesForHashing names: got %v want %v", gotNames, wantNames)
+	}
+
+	originalNames := []string{attributes[0].GetName(), attributes[1].GetName(), attributes[2].GetName()}
+	if !reflect.DeepEqual(originalNames, []string{"z_attr", "a_attr", "m_attr"}) {
+		t.Fatalf("sortedAttributesForHashing mutated input: %v", originalNames)
+	}
+}
+
+func TestCanonicalizeRuleInputs(t *testing.T) {
+	labelA := mustParseLabel("//pkg:a")
+	labelB := mustParseLabel("//pkg:b")
+	configA := NormalizeConfiguration("a")
+	configB := NormalizeConfiguration("b")
+
+	got := canonicalizeRuleInputs([]LabelAndConfigurations{
+		{Label: labelB, Configurations: []Configuration{configB, configA}},
+		{Label: labelA, Configurations: []Configuration{configB}},
+		{Label: labelB, Configurations: []Configuration{configA}},
+	})
+	want := []LabelAndConfigurations{
+		{Label: labelA, Configurations: []Configuration{configB}},
+		{Label: labelB, Configurations: []Configuration{configA, configB}},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("canonicalizeRuleInputs: got %#v want %#v", got, want)
+	}
+}
+
 func areHashesEqual(left, right []byte) bool {
 	return reflect.DeepEqual(left, right)
 }


### PR DESCRIPTION
Done with the help of codex and gpt-5.5 xhigh

  ## Summary

  Fix spurious affected-target results caused by order-sensitive hashing of Bazel query output.

  `target-determinator` may report unchanged targets as affected when Bazel emits
  equivalent rule metadata in a different order between two revisions. In particular,
  `configured_rule_input` entries can represent the same semantic dependency set
  while appearing in a different order in `cquery` output. Since TD previously hashed
  that emitted order directly, unchanged targets could receive different hashes.

  This mismatch also meant affected targets could be reported without meaningful
  change details: the diff walker already treats rule inputs as a set, while the hash
  path treated their order as significant.

  ## Bug introduction

The current reachable bug was introduced by:

  cfae1f39cebf17e1a2946c09b1db903beef94406
  Wed Aug 30 18:40:42 2023 +0100
  Support using configured rule inputs from 7.0.0 prereleases (#74)

  Why this commit: its parent had isConfiguredRuleInputsSupported hardcoded to false. This commit re-enabled configured_rule_input for Bazel >= 7.0.0-pre.20230628.2, while hashRule still iterated rule.ConfiguredRuleInput in Bazel
  output order. That made the order-sensitive hash path reachable again.

  There was an earlier brief introduction:

  b52b74ad5a509485fdf9bcba46be82425901dec2
  Tue Mar 28 18:44:49 2023 +0100
  Filter unmatching configuration-specific dependencies (#55)

  That first added order-sensitive configured-input hashing for Bazel 6, but it was disabled the next day by:

  5084fe0dde97da2a1c19e5448e3cf41db74b1bed
  Wed Mar 29 18:23:44 2023 +0100
  Disable configuration-specific narrowing

  ## Fix

  Canonicalize hash inputs before mixing them into the target hash:

  - Sort rule attributes before hashing.
  - Canonicalize configured rule inputs by label and configuration.
  - De-duplicate repeated label/configuration pairs.
  - Add unit tests covering both canonicalization paths.

  ## Validation

  - `bazel test //pkg:pkg_test`
  - `bazel build //target-determinator:target-determinator`