### PR TITLE
Parallel operations and many improvements

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -162,7 +162,6 @@ func ValidateCommonFlags(commandName string, flags *CommonFlags) (targetPattern 
 }
 
 func ResolveCommonConfig(commonFlags *CommonFlags, beforeRevStr string) (*CommonConfig, error) {
-
 	// Context attributes
 
 	workingDirectory, err := filepath.Abs(*commonFlags.WorkingDirectory)

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "@org_golang_google_protobuf//encoding/protodelim",
         "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//reflect/protoreflect",
     ],
 )
 

--- a/pkg/cache.go
+++ b/pkg/cache.go
@@ -48,12 +48,15 @@ type CacheKey struct {
 
 // SerializedQueryResults is the structure that gets saved to disk
 type SerializedQueryResults struct {
+	Version int
 	// Serialized protobuf of ConfiguredTargets
 	MatchingTargetsData []byte
 	BazelRelease        string
 	NormalizerMapping   map[string]string
 	// Key: "<label>\x00<config>", value: raw SHA256 bytes.
-	PrecomputedHashes map[string][]byte
+	PrecomputedHashes           map[string][]byte
+	PrecomputedSourceFileHashes map[string][]byte
+	MetadataFingerprints        map[string][]byte
 }
 
 // ComputeCacheKey generates a unique cache key based on the binary hash, git SHA, and CLI options
@@ -160,6 +163,9 @@ func LoadFromCache(context *Context, treeSHA string, targetPattern string) (*Que
 	if err := json.Unmarshal(data, &serialized); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal cache data: %w", err)
 	}
+	if serialized.Version != 2 {
+		return nil, fmt.Errorf("unsupported cache entry version %d", serialized.Version)
+	}
 
 	// Deserialize matching targets
 	matchingTargets, err := deserializeMatchingTargets(serialized.MatchingTargetsData)
@@ -181,6 +187,8 @@ func LoadFromCache(context *Context, treeSHA string, targetPattern string) (*Que
 	if err := queryResults.TargetHashCache.RestoreHashes(serialized.PrecomputedHashes); err != nil {
 		return nil, fmt.Errorf("failed to restore hashes from cache: %w", err)
 	}
+	queryResults.TargetHashCache.RestoreSourceFileHashes(serialized.PrecomputedSourceFileHashes)
+	queryResults.TargetHashCache.RestoreMetadataFingerprints(serialized.MetadataFingerprints)
 
 	log.Printf("Cache hit! Loaded results from cache")
 	return queryResults, nil
@@ -207,12 +215,19 @@ func SaveToCache(context *Context, gitSHA string, targetPattern string, queryRes
 	if err != nil {
 		return fmt.Errorf("failed to serialize matching targets: %w", err)
 	}
+	metadataFingerprints, err := queryResults.TargetHashCache.ExtractMetadataFingerprints()
+	if err != nil {
+		return fmt.Errorf("failed to serialize metadata fingerprints: %w", err)
+	}
 
 	serialized := SerializedQueryResults{
-		MatchingTargetsData: matchingTargetsData,
-		BazelRelease:        queryResults.BazelRelease,
-		NormalizerMapping:   queryResults.TargetHashCache.normalizer.Mapping,
-		PrecomputedHashes:   queryResults.TargetHashCache.ExtractHashes(),
+		Version:                     2,
+		MatchingTargetsData:         matchingTargetsData,
+		BazelRelease:                queryResults.BazelRelease,
+		NormalizerMapping:           queryResults.TargetHashCache.normalizer.Mapping,
+		PrecomputedHashes:           queryResults.TargetHashCache.ExtractHashes(),
+		PrecomputedSourceFileHashes: queryResults.TargetHashCache.ExtractSourceFileHashes(),
+		MetadataFingerprints:        metadataFingerprints,
 	}
 
 	data, err := json.Marshal(serialized)

--- a/pkg/configurations.go
+++ b/pkg/configurations.go
@@ -2,10 +2,16 @@ package pkg
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/wI2L/jsondiff"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 type Configuration struct {
@@ -83,4 +89,179 @@ func getConfigurationDetails(context *Context) (map[Configuration]singleConfigur
 		m[configuration] = c
 	}
 	return m, nil
+}
+
+func normalizeConfigurationDetails(context *Context, configurations map[Configuration]singleConfigurationOutput) (map[Configuration]Configuration, map[Configuration]singleConfigurationOutput, error) {
+	oldToNew := make(map[Configuration]Configuration, len(configurations))
+	normalizedConfigurations := make(map[Configuration]singleConfigurationOutput, len(configurations))
+	replacements := rootPathReplacements(context)
+
+	for oldConfiguration, configurationOutput := range configurations {
+		normalizedOutput, err := normalizeConfigurationOutput(configurationOutput, replacements)
+		if err != nil {
+			return nil, nil, err
+		}
+		configurationID, err := semanticConfigurationID(normalizedOutput)
+		if err != nil {
+			return nil, nil, err
+		}
+		newConfiguration := NormalizeConfiguration(configurationID)
+		normalizedOutput.ConfigHash = configurationID
+
+		if existing, ok := normalizedConfigurations[newConfiguration]; ok {
+			existingJSON, _ := json.Marshal(existing)
+			normalizedJSON, _ := json.Marshal(normalizedOutput)
+			if !bytes.Equal(existingJSON, normalizedJSON) {
+				return nil, nil, fmt.Errorf("configuration normalization collision for %s", configurationID)
+			}
+		}
+
+		oldToNew[oldConfiguration] = newConfiguration
+		normalizedConfigurations[newConfiguration] = normalizedOutput
+	}
+
+	return oldToNew, normalizedConfigurations, nil
+}
+
+func normalizeConfigurationOutput(configurationOutput singleConfigurationOutput, replacements []rootPathReplacement) (singleConfigurationOutput, error) {
+	normalized := configurationOutput
+	normalized.ConfigHash = ""
+
+	var err error
+	normalized.Fragments, err = normalizeRawJSONStrings(configurationOutput.Fragments, replacements)
+	if err != nil {
+		return singleConfigurationOutput{}, fmt.Errorf("failed to normalize configuration fragments: %w", err)
+	}
+	normalized.FragmentOptions, err = normalizeRawJSONStrings(configurationOutput.FragmentOptions, replacements)
+	if err != nil {
+		return singleConfigurationOutput{}, fmt.Errorf("failed to normalize configuration fragment options: %w", err)
+	}
+
+	return normalized, nil
+}
+
+func semanticConfigurationID(configurationOutput singleConfigurationOutput) (string, error) {
+	data, err := json.Marshal(configurationOutput)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal normalized configuration: %w", err)
+	}
+	hash := sha256.Sum256(data)
+	return hex.EncodeToString(hash[:]), nil
+}
+
+type rootPathReplacement struct {
+	from string
+	to   string
+}
+
+func rootPathReplacements(context *Context) []rootPathReplacement {
+	var replacements []rootPathReplacement
+	addReplacement := func(from string, to string) {
+		if from == "" {
+			return
+		}
+		from = filepath.Clean(from)
+		for _, replacement := range replacements {
+			if replacement.from == from {
+				return
+			}
+		}
+		replacements = append(replacements, rootPathReplacement{from: from, to: to})
+		if evaluated, err := filepath.EvalSymlinks(from); err == nil && evaluated != from {
+			replacements = append(replacements, rootPathReplacement{from: evaluated, to: to})
+		}
+	}
+
+	addReplacement(context.WorkspacePath, "${TARGET_DETERMINATOR_WORKSPACE}")
+	addReplacement(context.BazelOutputBase, "${TARGET_DETERMINATOR_OUTPUT_BASE}")
+	return replacements
+}
+
+func normalizeRawJSONStrings(raw json.RawMessage, replacements []rootPathReplacement) (json.RawMessage, error) {
+	if len(raw) == 0 {
+		return raw, nil
+	}
+
+	var value interface{}
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, err
+	}
+	normalized := normalizeJSONStrings(value, replacements)
+	return json.Marshal(normalized)
+}
+
+func normalizeJSONStrings(value interface{}, replacements []rootPathReplacement) interface{} {
+	switch typed := value.(type) {
+	case string:
+		return normalizeRootPathsInString(typed, replacements)
+	case []interface{}:
+		for idx, item := range typed {
+			typed[idx] = normalizeJSONStrings(item, replacements)
+		}
+		return typed
+	case map[string]interface{}:
+		for key, item := range typed {
+			typed[key] = normalizeJSONStrings(item, replacements)
+		}
+		return typed
+	default:
+		return value
+	}
+}
+
+func normalizeRootPathsInString(value string, replacements []rootPathReplacement) string {
+	for _, replacement := range replacements {
+		value = strings.ReplaceAll(value, replacement.from, replacement.to)
+	}
+	return value
+}
+
+func normalizeProtoStringFields(message proto.Message, replacements []rootPathReplacement) {
+	if message == nil || len(replacements) == 0 {
+		return
+	}
+
+	protoMessage := message.ProtoReflect()
+	protoMessage.Range(func(field protoreflect.FieldDescriptor, value protoreflect.Value) bool {
+		switch {
+		case field.IsList():
+			normalizeProtoListStrings(value.List(), field, replacements)
+		case field.IsMap():
+			normalizeProtoMapStrings(value.Map(), field, replacements)
+		case field.Kind() == protoreflect.StringKind:
+			protoMessage.Set(field, protoreflect.ValueOfString(normalizeRootPathsInString(value.String(), replacements)))
+		case field.Kind() == protoreflect.MessageKind || field.Kind() == protoreflect.GroupKind:
+			normalizeProtoStringFields(value.Message().Interface(), replacements)
+		}
+		return true
+	})
+}
+
+func normalizeProtoListStrings(list protoreflect.List, field protoreflect.FieldDescriptor, replacements []rootPathReplacement) {
+	switch field.Kind() {
+	case protoreflect.StringKind:
+		for idx := 0; idx < list.Len(); idx++ {
+			list.Set(idx, protoreflect.ValueOfString(normalizeRootPathsInString(list.Get(idx).String(), replacements)))
+		}
+	case protoreflect.MessageKind, protoreflect.GroupKind:
+		for idx := 0; idx < list.Len(); idx++ {
+			normalizeProtoStringFields(list.Get(idx).Message().Interface(), replacements)
+		}
+	}
+}
+
+func normalizeProtoMapStrings(protoMap protoreflect.Map, field protoreflect.FieldDescriptor, replacements []rootPathReplacement) {
+	valueField := field.MapValue()
+	switch valueField.Kind() {
+	case protoreflect.StringKind:
+		protoMap.Range(func(key protoreflect.MapKey, value protoreflect.Value) bool {
+			protoMap.Set(key, protoreflect.ValueOfString(normalizeRootPathsInString(value.String(), replacements)))
+			return true
+		})
+	case protoreflect.MessageKind, protoreflect.GroupKind:
+		protoMap.Range(func(_ protoreflect.MapKey, value protoreflect.Value) bool {
+			normalizeProtoStringFields(value.Message().Interface(), replacements)
+			return true
+		})
+	}
 }

--- a/pkg/hash_cache.go
+++ b/pkg/hash_cache.go
@@ -41,6 +41,7 @@ func NewTargetHashCache(
 		bazelRelease:                             bazelRelease,
 		bazelVersionSupportsConfiguredRuleInputs: bazelVersionSupportsConfiguredRuleInputs,
 		cache:                                    make(map[gazelle_label.Label]map[Configuration]*cacheEntry),
+		metadataFingerprints:                     make(map[string][]byte),
 		frozen:                                   false,
 	}
 }
@@ -65,6 +66,11 @@ func isConfiguredRuleInputsSupported(releaseString string) bool {
 type TargetHashCache struct {
 	context                                  map[gazelle_label.Label]map[Configuration]*analysis.ConfiguredTarget
 	fileHashCache                            *fileHashCache
+	workspacePath                            string
+	sourceFileRoot                           string
+	rootPathReplacements                     []rootPathReplacement
+	reusableSourceFileHashes                 *TargetHashCache
+	changedSourceFiles                       *ChangedPathSet
 	bazelRelease                             string
 	bazelVersionSupportsConfiguredRuleInputs bool
 
@@ -72,8 +78,138 @@ type TargetHashCache struct {
 
 	frozen bool
 
-	cacheLock sync.Mutex
-	cache     map[gazelle_label.Label]map[Configuration]*cacheEntry
+	cacheLock               sync.Mutex
+	cache                   map[gazelle_label.Label]map[Configuration]*cacheEntry
+	metadataFingerprintLock sync.Mutex
+	metadataFingerprints    map[string][]byte
+}
+
+func (thc *TargetHashCache) SetWorkspacePath(workspacePath string) {
+	thc.workspacePath = workspacePath
+	thc.sourceFileRoot = workspacePath
+}
+
+func (thc *TargetHashCache) WorkspacePath() string {
+	return thc.workspacePath
+}
+
+func (thc *TargetHashCache) UseSourceFileRoot(sourceFileRoot string) {
+	thc.sourceFileRoot = sourceFileRoot
+}
+
+func (thc *TargetHashCache) SetRootPathReplacements(replacements []rootPathReplacement) {
+	thc.rootPathReplacements = replacements
+}
+
+func (thc *TargetHashCache) ReuseUnchangedSourceFileHashesFrom(source *TargetHashCache, changedSourceFiles *ChangedPathSet) {
+	thc.reusableSourceFileHashes = source
+	thc.changedSourceFiles = changedSourceFiles
+}
+
+func (thc *TargetHashCache) sourceFileRelPath(absolutePath string) (string, bool) {
+	if thc.workspacePath == "" || thc.sourceFileRoot == "" {
+		return "", false
+	}
+
+	relPath, err := filepath.Rel(thc.workspacePath, absolutePath)
+	if err != nil || relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) || filepath.IsAbs(relPath) {
+		return "", false
+	}
+	return relPath, true
+}
+
+func (thc *TargetHashCache) sourceFilePath(absolutePath string) string {
+	relPath, ok := thc.sourceFileRelPath(absolutePath)
+	if !ok {
+		return absolutePath
+	}
+	return filepath.Join(thc.sourceFileRoot, relPath)
+}
+
+func (thc *TargetHashCache) hashSourceFile(absolutePath string) ([]byte, error) {
+	if thc.reusableSourceFileHashes != nil {
+		if relPath, ok := thc.sourceFileRelPath(absolutePath); ok {
+			relPath = filepath.ToSlash(relPath)
+			if !thc.changedSourceFiles.Contains(relPath) {
+				hash, ok, err := thc.reusableSourceFileHashes.hashSourceFileByRelPath(relPath)
+				if err != nil {
+					return nil, err
+				}
+				if ok {
+					thc.fileHashCache.Store(relPath, hash)
+					return hash, nil
+				}
+			}
+		}
+	}
+	return thc.fileHashCache.Hash(thc.sourceFilePath(absolutePath))
+}
+
+func (thc *TargetHashCache) hashSourceFileByRelPath(relPath string) ([]byte, bool, error) {
+	relPath = filepath.ToSlash(relPath)
+	if hash, ok := thc.fileHashCache.Lookup(relPath); ok {
+		return hash, true, nil
+	}
+	if thc.sourceFileRoot == "" {
+		return nil, false, nil
+	}
+	hash, err := thc.fileHashCache.Hash(filepath.Join(thc.sourceFileRoot, filepath.FromSlash(relPath)))
+	if err != nil {
+		return nil, false, err
+	}
+	thc.fileHashCache.Store(relPath, hash)
+	return hash, true, nil
+}
+
+type ChangedPathSet struct {
+	paths map[string]struct{}
+}
+
+func NewChangedPathSet(paths []string) *ChangedPathSet {
+	changedPathSet := &ChangedPathSet{paths: make(map[string]struct{}, len(paths))}
+	for _, changedPath := range paths {
+		changedPath = filepath.ToSlash(changedPath)
+		if changedPath == "" || changedPath == "." {
+			continue
+		}
+		changedPathSet.paths[changedPath] = struct{}{}
+	}
+	return changedPathSet
+}
+
+func (s *ChangedPathSet) Contains(relPath string) bool {
+	if s == nil {
+		return true
+	}
+	relPath = filepath.ToSlash(relPath)
+	for {
+		if _, ok := s.paths[relPath]; ok {
+			return true
+		}
+
+		parent := filepath.ToSlash(filepath.Dir(relPath))
+		if parent == "." || parent == relPath {
+			return false
+		}
+		relPath = parent
+	}
+}
+
+func (s *ChangedPathSet) ContainsBuildMetadataPath() bool {
+	if s == nil {
+		return true
+	}
+	for changedPath := range s.paths {
+		base := filepath.Base(changedPath)
+		if base == "BUILD" || base == "BUILD.bazel" || strings.HasSuffix(base, ".bzl") {
+			return true
+		}
+		switch changedPath {
+		case "MODULE.bazel", "MODULE.bazel.lock", "WORKSPACE", "WORKSPACE.bazel", ".bazelrc":
+			return true
+		}
+	}
+	return false
 }
 
 var labelNotFound = fmt.Errorf("label not found in context")
@@ -145,6 +281,10 @@ func (thc *TargetHashCache) Freeze() {
 	thc.frozen = true
 }
 
+func labelAndConfigurationCacheKey(labelAndConfiguration LabelAndConfiguration) string {
+	return labelAndConfiguration.Label.String() + "\x00" + labelAndConfiguration.Configuration.String()
+}
+
 // ExtractHashes collects all pre-computed hashes from the cache.
 // Keys are formatted as "<label>\x00<configuration>".
 // Only entries with a computed hash are included.
@@ -158,12 +298,55 @@ func (thc *TargetHashCache) ExtractHashes() map[string][]byte {
 			if entry.hash != nil {
 				hashCopy := make([]byte, len(entry.hash))
 				copy(hashCopy, entry.hash)
-				result[lbl.String()+"\x00"+cfg.String()] = hashCopy
+				result[labelAndConfigurationCacheKey(LabelAndConfiguration{Label: lbl, Configuration: cfg})] = hashCopy
 			}
 			entry.hashLock.Unlock()
 		}
 	}
 	return result
+}
+
+// ExtractSourceFileHashes collects source file hashes keyed by workspace-relative path.
+func (thc *TargetHashCache) ExtractSourceFileHashes() map[string][]byte {
+	result := make(map[string][]byte)
+	for path, hash := range thc.fileHashCache.ExtractHashes() {
+		relPath, ok := thc.sourceFileHashRelPath(path)
+		if !ok {
+			continue
+		}
+		result[relPath] = hash
+	}
+	return result
+}
+
+func (thc *TargetHashCache) sourceFileHashRelPath(path string) (string, bool) {
+	if path == "" {
+		return "", false
+	}
+	if !filepath.IsAbs(path) {
+		cleaned := filepath.ToSlash(filepath.Clean(path))
+		if cleaned == "." || strings.HasPrefix(cleaned, "../") || filepath.IsAbs(cleaned) {
+			return "", false
+		}
+		return cleaned, true
+	}
+	for _, root := range []string{thc.sourceFileRoot, thc.workspacePath} {
+		if root == "" {
+			continue
+		}
+		relPath, err := filepath.Rel(root, path)
+		if err != nil || relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) || filepath.IsAbs(relPath) {
+			continue
+		}
+		return filepath.ToSlash(relPath), true
+	}
+	return "", false
+}
+
+func (thc *TargetHashCache) RestoreSourceFileHashes(hashes map[string][]byte) {
+	for relPath, hash := range hashes {
+		thc.fileHashCache.Store(filepath.ToSlash(relPath), hash)
+	}
 }
 
 // RestoreHashes populates the cache with pre-computed hashes and freezes the cache.
@@ -190,6 +373,61 @@ func (thc *TargetHashCache) RestoreHashes(hashes map[string][]byte) error {
 	}
 	thc.frozen = true
 	return nil
+}
+
+func (thc *TargetHashCache) ExtractMetadataFingerprints() (map[string][]byte, error) {
+	result := make(map[string][]byte)
+	if thc.context == nil {
+		thc.metadataFingerprintLock.Lock()
+		defer thc.metadataFingerprintLock.Unlock()
+		for key, fingerprint := range thc.metadataFingerprints {
+			result[key] = copyBytes(fingerprint)
+		}
+		return result, nil
+	}
+
+	labels := make([]gazelle_label.Label, 0, len(thc.context))
+	for lbl := range thc.context {
+		labels = append(labels, lbl)
+	}
+	sort.Slice(labels, func(i, j int) bool {
+		return CompareLabels(labels[i], labels[j])
+	})
+	for _, lbl := range labels {
+		configurations := make([]Configuration, 0, len(thc.context[lbl]))
+		for configuration := range thc.context[lbl] {
+			configurations = append(configurations, configuration)
+		}
+		sort.Slice(configurations, func(i, j int) bool {
+			return ConfigurationLess(configurations[i], configurations[j])
+		})
+		for _, configuration := range configurations {
+			labelAndConfiguration := LabelAndConfiguration{Label: lbl, Configuration: configuration}
+			fingerprint, err := thc.MetadataFingerprint(labelAndConfiguration)
+			if err != nil {
+				return nil, err
+			}
+			result[labelAndConfigurationCacheKey(labelAndConfiguration)] = fingerprint
+		}
+	}
+	return result, nil
+}
+
+func (thc *TargetHashCache) RestoreMetadataFingerprints(fingerprints map[string][]byte) {
+	thc.metadataFingerprintLock.Lock()
+	defer thc.metadataFingerprintLock.Unlock()
+	for key, fingerprint := range fingerprints {
+		thc.metadataFingerprints[key] = copyBytes(fingerprint)
+	}
+}
+
+func copyBytes(value []byte) []byte {
+	if value == nil {
+		return nil
+	}
+	copied := make([]byte, len(value))
+	copy(copied, value)
+	return copied
 }
 
 func (thc *TargetHashCache) ParseCanonicalLabel(label string) (gazelle_label.Label, error) {
@@ -450,7 +688,9 @@ func (thc *TargetHashCache) AttributeForSerialization(rawAttr *build.Attribute) 
 		}
 	}
 
-	return thc.normalizer.NormalizeAttribute(&normalized)
+	normalizedAttribute := thc.normalizer.NormalizeAttribute(&normalized)
+	normalizeProtoStringFields(normalizedAttribute, thc.rootPathReplacements)
+	return normalizedAttribute
 }
 
 func equivalentAttributes(left, right *build.Attribute) bool {
@@ -505,7 +745,7 @@ func hashTarget(thc *TargetHashCache, labelAndConfiguration LabelAndConfiguratio
 	switch target.GetType() {
 	case build.Target_SOURCE_FILE:
 		absolutePath := AbsolutePath(target)
-		hash, err := thc.fileHashCache.Hash(absolutePath)
+		hash, err := thc.hashSourceFile(absolutePath)
 		if err != nil {
 			// Labels may be referred to without existing, and at loading time these are assumed
 			// to be input files, even if no such file exists.
@@ -548,6 +788,91 @@ func hashTarget(thc *TargetHashCache, labelAndConfiguration LabelAndConfiguratio
 	default:
 		return nil, fmt.Errorf("didn't know how to hash target %v with unknown rule type: %v", label, target.GetType())
 	}
+}
+
+func (thc *TargetHashCache) MetadataFingerprint(labelAndConfiguration LabelAndConfiguration) ([]byte, error) {
+	cacheKey := labelAndConfigurationCacheKey(labelAndConfiguration)
+	if fingerprint, ok := thc.lookupMetadataFingerprint(cacheKey); ok {
+		return fingerprint, nil
+	}
+
+	configurationMap, ok := thc.context[labelAndConfiguration.Label]
+	if !ok {
+		return nil, fmt.Errorf("label %s not found in context: %w", labelAndConfiguration.Label, labelNotFound)
+	}
+	configuredTarget, ok := configurationMap[labelAndConfiguration.Configuration]
+	if !ok {
+		return nil, fmt.Errorf("label %s configuration %s not found in context: %w", labelAndConfiguration.Label, labelAndConfiguration.Configuration, labelNotFound)
+	}
+
+	target := configuredTarget.Target
+	hasher := sha256.New()
+	switch target.GetType() {
+	case build.Target_SOURCE_FILE:
+		hasher.Write([]byte("source"))
+	case build.Target_RULE:
+		if !thc.bazelVersionSupportsConfiguredRuleInputs {
+			return nil, fmt.Errorf("metadata fingerprint requires configured rule inputs")
+		}
+		rule := target.Rule
+		configuration := configuredTarget.Configuration
+
+		hasher.Write([]byte("rule"))
+		hasher.Write([]byte(rule.GetRuleClass()))
+		hasher.Write([]byte(rule.GetSkylarkEnvironmentHashCode()))
+		hasher.Write([]byte(configuration.GetChecksum()))
+
+		for _, attr := range sortedAttributesForHashing(rule.GetAttribute()) {
+			normalizedAttribute := thc.AttributeForSerialization(attr)
+			protoBytes, err := proto.MarshalOptions{Deterministic: true}.Marshal(normalizedAttribute)
+			if err != nil {
+				return nil, err
+			}
+			hasher.Write(protoBytes)
+		}
+
+		ownConfiguration := NormalizeConfiguration(configuration.GetChecksum())
+		labelsAndConfigurations, err := getConfiguredRuleInputs(thc, rule, ownConfiguration)
+		if err != nil {
+			return nil, err
+		}
+		for _, ruleInputLabelAndConfigurations := range labelsAndConfigurations {
+			for _, ruleInputConfiguration := range ruleInputLabelAndConfigurations.Configurations {
+				writeLabel(hasher, ruleInputLabelAndConfigurations.Label)
+				hasher.Write(ruleInputConfiguration.ForHashing())
+			}
+		}
+	case build.Target_GENERATED_FILE:
+		generatingLabel, err := thc.ParseCanonicalLabel(*target.GeneratedFile.GeneratingRule)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse generated file generating rule label %s: %w", *target.GeneratedFile.GeneratingRule, err)
+		}
+		hasher.Write([]byte("generated"))
+		writeLabel(hasher, generatingLabel)
+	case build.Target_PACKAGE_GROUP:
+		hasher.Write([]byte("package_group"))
+	default:
+		return nil, fmt.Errorf("unknown target type for %s: %v", labelAndConfiguration.Label, target.GetType())
+	}
+	fingerprint := hasher.Sum(nil)
+	thc.storeMetadataFingerprint(cacheKey, fingerprint)
+	return fingerprint, nil
+}
+
+func (thc *TargetHashCache) lookupMetadataFingerprint(cacheKey string) ([]byte, bool) {
+	thc.metadataFingerprintLock.Lock()
+	defer thc.metadataFingerprintLock.Unlock()
+	fingerprint, ok := thc.metadataFingerprints[cacheKey]
+	if !ok {
+		return nil, false
+	}
+	return copyBytes(fingerprint), true
+}
+
+func (thc *TargetHashCache) storeMetadataFingerprint(cacheKey string, fingerprint []byte) {
+	thc.metadataFingerprintLock.Lock()
+	defer thc.metadataFingerprintLock.Unlock()
+	thc.metadataFingerprints[cacheKey] = copyBytes(fingerprint)
 }
 
 // If this function changes, so should WalkDiffs.
@@ -740,6 +1065,49 @@ type fileHashCache struct {
 type cacheEntry struct {
 	hashLock sync.Mutex
 	hash     []byte
+}
+
+func (hc *fileHashCache) Lookup(path string) ([]byte, bool) {
+	hc.cacheLock.Lock()
+	entry, ok := hc.cache[path]
+	hc.cacheLock.Unlock()
+	if !ok {
+		return nil, false
+	}
+	entry.hashLock.Lock()
+	defer entry.hashLock.Unlock()
+	if entry.hash == nil {
+		return nil, false
+	}
+	return copyBytes(entry.hash), true
+}
+
+func (hc *fileHashCache) Store(path string, hash []byte) {
+	hc.cacheLock.Lock()
+	entry, ok := hc.cache[path]
+	if !ok {
+		entry = &cacheEntry{}
+		hc.cache[path] = entry
+	}
+	hc.cacheLock.Unlock()
+
+	entry.hashLock.Lock()
+	defer entry.hashLock.Unlock()
+	entry.hash = copyBytes(hash)
+}
+
+func (hc *fileHashCache) ExtractHashes() map[string][]byte {
+	result := make(map[string][]byte)
+	hc.cacheLock.Lock()
+	defer hc.cacheLock.Unlock()
+	for path, entry := range hc.cache {
+		entry.hashLock.Lock()
+		if entry.hash != nil {
+			result[path] = copyBytes(entry.hash)
+		}
+		entry.hashLock.Unlock()
+	}
+	return result
 }
 
 // Hash computes the digest of the contents of a file at the given path, and caches the result.

--- a/pkg/target_determinator.go
+++ b/pkg/target_determinator.go
@@ -709,6 +709,7 @@ func gitStatus(workingDirectory string) ([]GitFileStatus, error) {
 //
 // When applicable, the caller is responsible for cleaning up the newly created worktree.
 func gitSafeCheckout(context *Context, rev LabelledGitRev, ignoredFiles []common.RelPath) (string, error) {
+	originalWorkspacePath := context.WorkspacePath
 	isPreCheckoutClean, err := EnsureGitRepositoryClean(context.WorkspacePath, ignoredFiles)
 	if err != nil {
 		return "", fmt.Errorf("failed to check whether the repository is clean: %w", err)
@@ -738,7 +739,14 @@ func gitSafeCheckout(context *Context, rev LabelledGitRev, ignoredFiles []common
 
 		log.Printf("Detected unclean repository after checkout (likely due to submodule or " +
 			".gitignore changes). Using git worktree to leave original repository pristine.")
-		return checkoutWorktree(context, rev)
+		newWorkspacePath, err := checkoutWorktree(context, rev)
+		if err != nil {
+			return newWorkspacePath, err
+		}
+		if err := gitCheckout(originalWorkspacePath, context.OriginalRevision); err != nil {
+			return newWorkspacePath, fmt.Errorf("failed to restore original repository after creating worktree for %v: %w", rev, err)
+		}
+		return newWorkspacePath, nil
 	}
 
 	return updateSubmodules(context.WorkspacePath, rev, "")

--- a/pkg/target_determinator.go
+++ b/pkg/target_determinator.go
@@ -152,7 +152,7 @@ type Context struct {
 // FullyProcess returns the before and after metadata maps, with fully filled caches.
 func FullyProcess(context *Context, revBefore LabelledGitRev, revAfter LabelledGitRev, targets TargetsList) (*QueryResults, *QueryResults, error) {
 	log.Printf("Processing %s", revBefore)
-	queryInfoBefore, err := fullyProcessRevision(context, revBefore, targets)
+	queryInfoBefore, completeBefore, err := fullyProcessRevision(context, revBefore, targets, true, nil)
 	if err != nil {
 		if queryInfoBefore == nil {
 			return nil, nil, err
@@ -165,11 +165,71 @@ func FullyProcess(context *Context, revBefore LabelledGitRev, revAfter LabelledG
 		}
 	}
 
-	// At this point, we assume that the working copy is back to its pristine state.
+	var changedPaths *ChangedPathSet
+	reuseSourceFileHashes := false
+	if queryInfoBefore != nil && queryInfoBefore.QueryError == nil {
+		var changedPathsErr error
+		changedPaths, changedPathsErr = GitChangedPaths(context, revBefore, revAfter)
+		if changedPathsErr != nil {
+			log.Printf("Source file hash reuse disabled: failed to determine changed files: %v", changedPathsErr)
+		} else {
+			reuseSourceFileHashes = true
+		}
+	}
+
+	configureAfter := func(queryInfo *QueryResults) bool {
+		if reuseSourceFileHashes {
+			queryInfo.TargetHashCache.ReuseUnchangedSourceFileHashesFrom(queryInfoBefore.TargetHashCache, changedPaths)
+			if metadataAndSourceChangesProveNoAffectedTargets(queryInfoBefore, queryInfo, changedPaths) {
+				log.Printf("Skipping hash prefill: cquery metadata is unchanged and changed files are outside the transitive source graph")
+				queryInfo.NoAffectedTargets = true
+				return true
+			}
+		}
+		return false
+	}
+
+	// The before revision hashes can be filled while the main working copy is available for the
+	// after revision.
 	log.Printf("Processing %s", revAfter)
-	queryInfoAfter, err := fullyProcessRevision(context, revAfter, targets)
+	queryInfoAfter, completeAfter, err := fullyProcessRevision(context, revAfter, targets, true, configureAfter)
 	if err != nil {
+		if completeBefore != nil {
+			if completeErr := completeBefore(); completeErr != nil {
+				return nil, nil, fmt.Errorf("after revision failed after before prefill also failed: after error: %w; before completion error: %v", err, completeErr)
+			}
+		}
 		return nil, nil, err
+	}
+
+	complete := func(rev LabelledGitRev, completePrefill func() error) error {
+		if completePrefill == nil {
+			return nil
+		}
+		if err := completePrefill(); err != nil {
+			return fmt.Errorf("failed to complete cache prefilling for %s: %w", rev, err)
+		}
+		return nil
+	}
+	if reuseSourceFileHashes {
+		if err := complete(revAfter, completeAfter); err != nil {
+			if completeBefore != nil {
+				if completeErr := completeBefore(); completeErr != nil {
+					return nil, nil, fmt.Errorf("%w; also failed to complete cache prefilling for %s: %v", err, revBefore, completeErr)
+				}
+			}
+			return nil, nil, err
+		}
+		if err := complete(revBefore, completeBefore); err != nil {
+			return nil, nil, err
+		}
+	} else {
+		if err := complete(revBefore, completeBefore); err != nil {
+			return nil, nil, err
+		}
+		if err := complete(revAfter, completeAfter); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	return queryInfoBefore, queryInfoAfter, nil
@@ -180,20 +240,13 @@ func FullyProcess(context *Context, revBefore LabelledGitRev, revAfter LabelledG
 // but that the user may want to use the results anyway, despite their query results being empty.
 // This may be useful when the "before" commit is broken for query, as it allows for running all
 // matching targets from the "after" query, despite the "before" being broken.
-func fullyProcessRevision(context *Context, rev LabelledGitRev, targets TargetsList) (queryInfo *QueryResults, err error) {
-	defer func() {
-		innerErr := gitCheckout(context.WorkspacePath, context.OriginalRevision)
-		if innerErr != nil && err == nil {
-			err = fmt.Errorf("failed to check out original commit during cleanup: %v", innerErr)
-		}
-	}()
-
+func fullyProcessRevision(context *Context, rev LabelledGitRev, targets TargetsList, asyncPrefill bool, configureQueryInfo func(*QueryResults) bool) (queryInfo *QueryResults, completePrefill func() error, err error) {
 	var treeSha string
 	cacheEnabled := context.CacheDirectory != "" && !context.NoCacheResults
 	if cacheEnabled && rev.GitRevision == CurrentWorkingCopyState {
 		uncleanStatuses, err := GitStatusFiltered(context.WorkspacePath, context.IgnoredFiles)
 		if err != nil {
-			return nil, fmt.Errorf("failed to check git status for caching: %w", err)
+			return nil, nil, fmt.Errorf("failed to check git status for caching: %w", err)
 		}
 		if len(uncleanStatuses) > 0 {
 			log.Println("Skipping cache: working copy is unclean")
@@ -209,7 +262,7 @@ func fullyProcessRevision(context *Context, rev LabelledGitRev, targets TargetsL
 		var treeErr error
 		treeSha, treeErr = GitTreeSHA(context, gitRev)
 		if treeErr != nil {
-			return nil, fmt.Errorf("failed to compute tree SHA for %s: %w", rev, treeErr)
+			return nil, nil, fmt.Errorf("failed to compute tree SHA for %s: %w", rev, treeErr)
 		}
 
 		if context.IncludeDifferences {
@@ -219,31 +272,125 @@ func fullyProcessRevision(context *Context, rev LabelledGitRev, targets TargetsL
 			cachedResults, cacheErr := LoadFromCache(context, treeSha, targets.String())
 			if cacheErr == nil {
 				log.Println("Cache hit: returning cached results")
-				return cachedResults, nil
+				return cachedResults, nil, nil
 			}
 			log.Printf("Cache load failed: %v", cacheErr)
 		}
 	}
 
 	queryInfo, loadMetadataCleanup, err := LoadIncompleteMetadata(context, rev, targets)
-	defer loadMetadataCleanup()
 	if err != nil {
-		return queryInfo, fmt.Errorf("failed to load metadata at %s: %w", rev, err)
+		loadMetadataCleanup()
+		if checkoutErr := gitCheckout(context.WorkspacePath, context.OriginalRevision); checkoutErr != nil {
+			return queryInfo, nil, fmt.Errorf("failed to load metadata at %s: %w; also failed to check out original commit during cleanup: %v", rev, err, checkoutErr)
+		}
+		return queryInfo, nil, fmt.Errorf("failed to load metadata at %s: %w", rev, err)
 	}
 
-	log.Println("Hashing targets")
-	if err := queryInfo.PrefillCache(); err != nil {
-		return nil, fmt.Errorf("failed to calculate hashes at %s: %w", rev, err)
+	cleanupAfterHash := loadMetadataCleanup
+	restoreAfterHash := true
+	if asyncPrefill && rev.GitRevision != CurrentWorkingCopyState {
+		cleanupAfterHash, err = prepareAsyncPrefill(context, rev, queryInfo, loadMetadataCleanup)
+		if err != nil {
+			return queryInfo, nil, err
+		}
+		restoreAfterHash = false
+	}
+	runCleanup := func(prefillErr error) error {
+		cleanupAfterHash()
+		if restoreAfterHash {
+			if checkoutErr := gitCheckout(context.WorkspacePath, context.OriginalRevision); checkoutErr != nil && prefillErr == nil {
+				return fmt.Errorf("failed to check out original commit during cleanup: %w", checkoutErr)
+			} else if checkoutErr != nil {
+				return fmt.Errorf("%w; also failed to check out original commit during cleanup: %v", prefillErr, checkoutErr)
+			}
+		}
+		return prefillErr
 	}
 
-	// Save to cache if caching is enabled
-	if cacheEnabled {
-		if saveErr := SaveToCache(context, treeSha, targets.String(), queryInfo); saveErr != nil {
-			log.Printf("Warning: failed to save to cache: %v", saveErr)
+	skipPrefill := false
+	if configureQueryInfo != nil {
+		skipPrefill = configureQueryInfo(queryInfo)
+	}
+	if skipPrefill {
+		return queryInfo, nil, runCleanup(nil)
+	}
+
+	prefill := func() error {
+		log.Println("Hashing targets")
+		if err := queryInfo.PrefillCache(); err != nil {
+			return fmt.Errorf("failed to calculate hashes at %s: %w", rev, err)
+		}
+
+		// Save to cache if caching is enabled
+		if cacheEnabled {
+			if saveErr := SaveToCache(context, treeSha, targets.String(), queryInfo); saveErr != nil {
+				log.Printf("Warning: failed to save to cache: %v", saveErr)
+			}
+		}
+		return nil
+	}
+
+	if !asyncPrefill {
+		if err := prefill(); err != nil {
+			return nil, nil, runCleanup(err)
+		}
+		return queryInfo, nil, runCleanup(nil)
+	}
+
+	prefillDone := make(chan error, 1)
+	go func() {
+		prefillDone <- prefill()
+	}()
+
+	completePrefill = func() error {
+		return runCleanup(<-prefillDone)
+	}
+
+	return queryInfo, completePrefill, nil
+}
+
+func prepareAsyncPrefill(context *Context, rev LabelledGitRev, queryInfo *QueryResults, loadMetadataCleanup func()) (func(), error) {
+	cleanupAfterHash := loadMetadataCleanup
+	restoreWorkspace := true
+
+	if queryInfo.TargetHashCache.WorkspacePath() == context.WorkspacePath {
+		sourceFileRoot, err := gitReuseOrCreateWorktree(context, rev)
+		if err != nil {
+			loadMetadataCleanup()
+			if checkoutErr := gitCheckout(context.WorkspacePath, context.OriginalRevision); checkoutErr != nil {
+				return nil, fmt.Errorf("failed to create stable source file root for %s: %w; also failed to check out original commit during cleanup: %v", rev, err, checkoutErr)
+			}
+			return nil, fmt.Errorf("failed to create stable source file root for %s: %w", rev, err)
+		}
+		if _, err := updateSubmodules(sourceFileRoot, rev, sourceFileRoot); err != nil {
+			loadMetadataCleanup()
+			if checkoutErr := gitCheckout(context.WorkspacePath, context.OriginalRevision); checkoutErr != nil {
+				return nil, fmt.Errorf("failed to update stable source file root for %s: %w; also failed to check out original commit during cleanup: %v", rev, err, checkoutErr)
+			}
+			return nil, fmt.Errorf("failed to update stable source file root for %s: %w", rev, err)
+		}
+
+		queryInfo.TargetHashCache.UseSourceFileRoot(sourceFileRoot)
+		if context.DeleteCachedWorktree {
+			cleanupAfterHash = func() {
+				loadMetadataCleanup()
+				if err := os.RemoveAll(sourceFileRoot); err != nil {
+					log.Printf("failed to clean up source file worktree at %s: %v", sourceFileRoot, err)
+				}
+			}
+		}
+	} else {
+		restoreWorkspace = false
+	}
+
+	if restoreWorkspace {
+		if checkoutErr := gitCheckout(context.WorkspacePath, context.OriginalRevision); checkoutErr != nil {
+			cleanupAfterHash()
+			return nil, fmt.Errorf("failed to check out original commit before asynchronous hashing: %w", checkoutErr)
 		}
 	}
-
-	return queryInfo, nil
+	return cleanupAfterHash, nil
 }
 
 // LoadIncompleteMetadata loads the metadata about, but not hashes of, targets into a QueryResults.
@@ -388,6 +535,124 @@ func GitTreeSHA(context *Context, gitRev string) (string, error) {
 	return strings.TrimSpace(stdoutBuf.String()), nil
 }
 
+func GitChangedPaths(context *Context, revBefore LabelledGitRev, revAfter LabelledGitRev) (*ChangedPathSet, error) {
+	if revBefore.GitRevision.Sha == "" {
+		return nil, fmt.Errorf("before revision must resolve to a git SHA")
+	}
+
+	afterRev := revAfter.GitRevision.Sha
+	if revAfter.GitRevision == CurrentWorkingCopyState {
+		isClean, err := EnsureGitRepositoryClean(context.WorkspacePath, context.IgnoredFiles)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check whether current working copy is clean: %w", err)
+		}
+		if !isClean {
+			return nil, fmt.Errorf("current working copy is dirty")
+		}
+		afterRev = context.OriginalRevision.GitRevision.Sha
+	}
+	if afterRev == "" {
+		return nil, fmt.Errorf("after revision must resolve to a git SHA")
+	}
+
+	changedPaths, err := runToLines(context.WorkspacePath, "git", "diff", "--name-only", "--no-renames", revBefore.GitRevision.Sha, afterRev)
+	if err != nil {
+		return nil, err
+	}
+	return NewChangedPathSet(changedPaths), nil
+}
+
+func metadataAndSourceChangesProveNoAffectedTargets(before, after *QueryResults, changedPaths *ChangedPathSet) bool {
+	if before == nil || after == nil || changedPaths == nil {
+		log.Printf("Hash prefill fast path disabled: missing query results or changed paths")
+		return false
+	}
+	if before.QueryError != nil || after.QueryError != nil {
+		log.Printf("Hash prefill fast path disabled: query error present")
+		return false
+	}
+	if before.BazelRelease != after.BazelRelease {
+		log.Printf("Hash prefill fast path disabled: Bazel release differs")
+		return false
+	}
+	if changedPaths.ContainsBuildMetadataPath() {
+		log.Printf("Hash prefill fast path disabled: build metadata path changed")
+		return false
+	}
+	if !matchingTargetsEqual(before.MatchingTargets, after.MatchingTargets) {
+		log.Printf("Hash prefill fast path disabled: matching targets differ")
+		return false
+	}
+	equalMetadata, err := semanticMetadataEqual(before, after)
+	if err != nil {
+		log.Printf("Hash prefill fast path disabled: failed to compare semantic cquery metadata: %v", err)
+		return false
+	}
+	if !equalMetadata {
+		log.Printf("Hash prefill fast path disabled: semantic cquery metadata differs")
+		return false
+	}
+	if changedPathsIntersectSourceFiles(after, changedPaths) {
+		log.Printf("Hash prefill fast path disabled: changed files intersect transitive source graph")
+		return false
+	}
+	return true
+}
+
+func semanticMetadataEqual(before, after *QueryResults) (bool, error) {
+	beforeFingerprints, err := before.TargetHashCache.ExtractMetadataFingerprints()
+	if err != nil {
+		return false, fmt.Errorf("failed to extract before metadata fingerprints: %w", err)
+	}
+	afterFingerprints, err := after.TargetHashCache.ExtractMetadataFingerprints()
+	if err != nil {
+		return false, fmt.Errorf("failed to extract after metadata fingerprints: %w", err)
+	}
+	if len(beforeFingerprints) != len(afterFingerprints) {
+		return false, nil
+	}
+	for key, beforeFingerprint := range beforeFingerprints {
+		afterFingerprint, ok := afterFingerprints[key]
+		if !ok {
+			return false, nil
+		}
+		if !bytes.Equal(beforeFingerprint, afterFingerprint) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func matchingTargetsEqual(before, after *MatchingTargets) bool {
+	beforeLabels := before.Labels()
+	afterLabels := after.Labels()
+	if !reflect.DeepEqual(beforeLabels, afterLabels) {
+		return false
+	}
+	for _, l := range beforeLabels {
+		if !reflect.DeepEqual(before.ConfigurationsFor(l), after.ConfigurationsFor(l)) {
+			return false
+		}
+	}
+	return true
+}
+
+func changedPathsIntersectSourceFiles(queryInfo *QueryResults, changedPaths *ChangedPathSet) bool {
+	for _, configuredTargetsByConfig := range queryInfo.TransitiveConfiguredTargets {
+		for _, configuredTarget := range configuredTargetsByConfig {
+			target := configuredTarget.GetTarget()
+			if target.GetType() != build.Target_SOURCE_FILE {
+				continue
+			}
+			relPath, ok := queryInfo.TargetHashCache.sourceFileRelPath(AbsolutePath(target))
+			if ok && changedPaths.Contains(relPath) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 type GitFileStatus struct {
 	// Status contains the shorthand notation of the status of the file. See `man git-status` for a mapping.
 	Status string
@@ -444,7 +709,6 @@ func gitStatus(workingDirectory string) ([]GitFileStatus, error) {
 //
 // When applicable, the caller is responsible for cleaning up the newly created worktree.
 func gitSafeCheckout(context *Context, rev LabelledGitRev, ignoredFiles []common.RelPath) (string, error) {
-	useGitWorktree := false
 	isPreCheckoutClean, err := EnsureGitRepositoryClean(context.WorkspacePath, ignoredFiles)
 	if err != nil {
 		return "", fmt.Errorf("failed to check whether the repository is clean: %w", err)
@@ -456,37 +720,42 @@ func gitSafeCheckout(context *Context, rev LabelledGitRev, ignoredFiles []common
 
 		log.Printf("Workspace is unclean, using git worktree. This will be slower the first time. " +
 			"You can avoid this by committing local changes and ignoring untracked files.")
-		useGitWorktree = true
-	} else {
-		if err := gitCheckout(context.WorkspacePath, rev); err != nil {
-			return "", err
-		}
-
-		isPostCheckoutClean, err := EnsureGitRepositoryClean(context.WorkspacePath, ignoredFiles)
-		if err != nil {
-			return "", fmt.Errorf("failed to check whether the repository is clean: %w", err)
-		}
-		if !isPostCheckoutClean {
-			if context.EnforceCleanRepo {
-				return "", fmt.Errorf("repository was not clean after checking out %v", rev)
-			}
-
-			log.Printf("Detected unclean repository after checkout (likely due to submodule or " +
-				".gitignore changes). Using git worktree to leave original repository pristine.")
-			useGitWorktree = true
-		}
-	}
-	newRepositoryPath := ""
-	if useGitWorktree {
-		newRepositoryPath, err = gitReuseOrCreateWorktree(context, rev)
-		if err != nil {
-			return "", fmt.Errorf("failed to create or reuse worktree: %w", err)
-		}
-		context.WorkspacePath = newRepositoryPath
+		return checkoutWorktree(context, rev)
 	}
 
+	if err := gitCheckout(context.WorkspacePath, rev); err != nil {
+		return "", err
+	}
+
+	isPostCheckoutClean, err := EnsureGitRepositoryClean(context.WorkspacePath, ignoredFiles)
+	if err != nil {
+		return "", fmt.Errorf("failed to check whether the repository is clean: %w", err)
+	}
+	if !isPostCheckoutClean {
+		if context.EnforceCleanRepo {
+			return "", fmt.Errorf("repository was not clean after checking out %v", rev)
+		}
+
+		log.Printf("Detected unclean repository after checkout (likely due to submodule or " +
+			".gitignore changes). Using git worktree to leave original repository pristine.")
+		return checkoutWorktree(context, rev)
+	}
+
+	return updateSubmodules(context.WorkspacePath, rev, "")
+}
+
+func checkoutWorktree(context *Context, rev LabelledGitRev) (string, error) {
+	newRepositoryPath, err := gitReuseOrCreateWorktree(context, rev)
+	if err != nil {
+		return "", fmt.Errorf("failed to create or reuse worktree: %w", err)
+	}
+	context.WorkspacePath = newRepositoryPath
+	return updateSubmodules(context.WorkspacePath, rev, newRepositoryPath)
+}
+
+func updateSubmodules(workingDirectory string, rev LabelledGitRev, newRepositoryPath string) (string, error) {
 	gitCmd := exec.Command("git", "submodule", "update", "--init", "--recursive")
-	gitCmd.Dir = context.WorkspacePath
+	gitCmd.Dir = workingDirectory
 	if output, err := gitCmd.CombinedOutput(); err != nil {
 		return newRepositoryPath, fmt.Errorf("failed to update submodules during checkout %s: %w. Output: %v", rev, err, string(output))
 	}
@@ -584,6 +853,7 @@ type QueryResults struct {
 	TransitiveConfiguredTargets map[label.Label]map[Configuration]*analysis.ConfiguredTarget
 	TargetHashCache             *TargetHashCache
 	BazelRelease                string
+	NoAffectedTargets           bool
 	// QueryError is whatever error was returned when running the cquery to get these results.
 	QueryError     error
 	configurations map[Configuration]singleConfigurationOutput
@@ -790,7 +1060,7 @@ func doQueryDeps(context *Context, targets TargetsList) (*QueryResults, error) {
 	if len(incompatibleTargetsToFilter) > 0 {
 		depsPattern += " - " + strings.Join(sortedStringKeys(incompatibleTargetsToFilter), " - ")
 	}
-	transitiveResult, err := runToCqueryResult(context, depsPattern, true, bazelRelease)
+	transitiveOutput, err := runToCqueryOutput(context, depsPattern, true, bazelRelease)
 	if err != nil {
 		retErr := fmt.Errorf("failed to cquery %v: %w", depsPattern, err)
 		return &QueryResults{
@@ -799,28 +1069,57 @@ func doQueryDeps(context *Context, targets TargetsList) (*QueryResults, error) {
 				labelsToConfigurations: nil,
 			},
 			TransitiveConfiguredTargets: nil,
-			TargetHashCache:             NewTargetHashCache(nil, &normalizer, bazelRelease),
+			TargetHashCache:             targetHashCache(nil, &normalizer, bazelRelease, context),
 			BazelRelease:                bazelRelease,
 			QueryError:                  retErr,
 		}, retErr
 	}
 
-	transitiveConfiguredTargets, err := ParseCqueryResult(transitiveResult, &normalizer)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse cquery result: %w", err)
-	}
+	transitiveResultDone := make(chan transitiveResult, 1)
+	go func() {
+		transitiveConfiguredTargets, err := parseTransitiveCqueryResult(transitiveOutput, &normalizer)
+		transitiveResultDone <- transitiveResult{configuredTargets: transitiveConfiguredTargets, err: err}
+	}()
 
 	matchingTargetResults, err := runToCqueryResult(context, targets.String(), false, bazelRelease)
 	if err != nil {
+		transitiveResult := <-transitiveResultDone
+		if transitiveResult.err != nil {
+			return nil, fmt.Errorf("failed to run top-level cquery: %w; also failed to parse transitive cquery result: %v", err, transitiveResult.err)
+		}
 		return nil, fmt.Errorf("failed to run top-level cquery: %w", err)
 	}
 
 	var compatibleTargets map[label.Label]bool
 	if context.FilterIncompatibleTargets {
 		if compatibleTargets, err = findCompatibleTargets(context, targets.String(), true, &normalizer, bazelRelease); err != nil {
+			transitiveResult := <-transitiveResultDone
+			if transitiveResult.err != nil {
+				return nil, fmt.Errorf("failed to find compatible targets: %w; also failed to parse transitive cquery result: %v", err, transitiveResult.err)
+			}
 			return nil, fmt.Errorf("failed to find compatible targets: %w", err)
 		}
 	}
+
+	transitiveResult := <-transitiveResultDone
+	if transitiveResult.err != nil {
+		return nil, fmt.Errorf("failed to parse cquery result: %w", transitiveResult.err)
+	}
+	transitiveConfiguredTargets := transitiveResult.configuredTargets
+
+	configurations, err := getConfigurationDetails(context)
+	if err != nil {
+		return nil, fmt.Errorf("failed to interpret configurations output: %w", err)
+	}
+	configurationMap, configurations, err := normalizeConfigurationDetails(context, configurations)
+	if err != nil {
+		return nil, fmt.Errorf("failed to normalize configurations: %w", err)
+	}
+	transitiveConfiguredTargets, err = normalizeConfiguredTargets(transitiveConfiguredTargets, configurationMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to normalize transitive cquery configurations: %w", err)
+	}
+
 	// Need to do this due to a change in bazel-gazelle & how equality between labels is determined.
 	// Likely happened in https://github.com/bazel-contrib/bazel-gazelle/pull/1911.
 	var compatibleTargetsStrKey = make(map[string]bool, len(compatibleTargets))
@@ -841,7 +1140,10 @@ func doQueryDeps(context *Context, targets TargetsList) (*QueryResults, error) {
 		}
 		labels = append(labels, l)
 
-		configuration := NormalizeConfiguration(mt.Configuration.Checksum)
+		configuration, err := remapConfiguration(NormalizeConfiguration(mt.Configuration.Checksum), configurationMap)
+		if err != nil {
+			return nil, fmt.Errorf("failed to normalize matching target configuration for %s: %w", l, err)
+		}
 		labelsToConfigurations[l] = append(labelsToConfigurations[l], configuration)
 	}
 
@@ -855,20 +1157,84 @@ func doQueryDeps(context *Context, targets TargetsList) (*QueryResults, error) {
 		labelsToConfigurations: processedLabelsToConfigurations,
 	}
 
-	configurations, err := getConfigurationDetails(context)
-	if err != nil {
-		return nil, fmt.Errorf("failed to interpret configurations output: %w", err)
-	}
-
 	queryResults := &QueryResults{
 		MatchingTargets:             matchingTargets,
 		TransitiveConfiguredTargets: transitiveConfiguredTargets,
-		TargetHashCache:             NewTargetHashCache(transitiveConfiguredTargets, &normalizer, bazelRelease),
+		TargetHashCache:             targetHashCache(transitiveConfiguredTargets, &normalizer, bazelRelease, context),
 		BazelRelease:                bazelRelease,
 		QueryError:                  nil,
 		configurations:              configurations,
 	}
 	return queryResults, nil
+}
+
+func targetHashCache(
+	configuredTargets map[label.Label]map[Configuration]*analysis.ConfiguredTarget,
+	normalizer *Normalizer,
+	bazelRelease string,
+	context *Context,
+) *TargetHashCache {
+	cache := NewTargetHashCache(configuredTargets, normalizer, bazelRelease)
+	cache.SetWorkspacePath(context.WorkspacePath)
+	cache.SetRootPathReplacements(rootPathReplacements(context))
+	return cache
+}
+
+func normalizeConfiguredTargets(configuredTargets map[label.Label]map[Configuration]*analysis.ConfiguredTarget, configurationMap map[Configuration]Configuration) (map[label.Label]map[Configuration]*analysis.ConfiguredTarget, error) {
+	normalized := make(map[label.Label]map[Configuration]*analysis.ConfiguredTarget, len(configuredTargets))
+	for l, configuredTargetsByConfig := range configuredTargets {
+		normalized[l] = make(map[Configuration]*analysis.ConfiguredTarget, len(configuredTargetsByConfig))
+		for oldConfiguration, configuredTarget := range configuredTargetsByConfig {
+			newConfiguration, err := remapConfiguration(oldConfiguration, configurationMap)
+			if err != nil {
+				return nil, fmt.Errorf("failed to remap configuration for %s: %w", l, err)
+			}
+			if err := normalizeConfiguredTargetConfiguration(configuredTarget, configurationMap); err != nil {
+				return nil, fmt.Errorf("failed to normalize configured target %s: %w", l, err)
+			}
+
+			if existing := normalized[l][newConfiguration]; existing != nil && !proto.Equal(existing, configuredTarget) {
+				return nil, fmt.Errorf("configuration normalization collision for %s in configuration %s", l, newConfiguration)
+			}
+			normalized[l][newConfiguration] = configuredTarget
+		}
+	}
+	return normalized, nil
+}
+
+func normalizeConfiguredTargetConfiguration(configuredTarget *analysis.ConfiguredTarget, configurationMap map[Configuration]Configuration) error {
+	if configuredTarget.GetConfiguration() != nil {
+		configuration, err := remapConfiguration(NormalizeConfiguration(configuredTarget.GetConfiguration().GetChecksum()), configurationMap)
+		if err != nil {
+			return err
+		}
+		configuredTarget.GetConfiguration().Checksum = configuration.String()
+	}
+
+	rule := configuredTarget.GetTarget().GetRule()
+	if rule == nil {
+		return nil
+	}
+	for _, configuredRuleInput := range rule.GetConfiguredRuleInput() {
+		configuration, err := remapConfiguration(NormalizeConfiguration(configuredRuleInput.GetConfigurationChecksum()), configurationMap)
+		if err != nil {
+			return err
+		}
+		configurationChecksum := configuration.String()
+		configuredRuleInput.ConfigurationChecksum = &configurationChecksum
+	}
+	return nil
+}
+
+func remapConfiguration(configuration Configuration, configurationMap map[Configuration]Configuration) (Configuration, error) {
+	if configuration.String() == "" {
+		return configuration, nil
+	}
+	newConfiguration, ok := configurationMap[configuration]
+	if !ok {
+		return Configuration{}, fmt.Errorf("configuration %s not found in normalized configuration map", configuration)
+	}
+	return newConfiguration, nil
 }
 
 func sortedStringKeys[V any](m map[label.Label]V) []string {
@@ -880,7 +1246,25 @@ func sortedStringKeys[V any](m map[label.Label]V) []string {
 	return keys
 }
 
+type cqueryOutput struct {
+	stdout           []byte
+	useStreamedProto bool
+}
+
+type transitiveResult struct {
+	configuredTargets map[label.Label]map[Configuration]*analysis.ConfiguredTarget
+	err               error
+}
+
 func runToCqueryResult(context *Context, pattern string, includeTransitions bool, bazelRelease string) ([]*analysis.ConfiguredTarget, error) {
+	output, err := runToCqueryOutput(context, pattern, includeTransitions, bazelRelease)
+	if err != nil {
+		return nil, err
+	}
+	return parseCqueryOutput(output)
+}
+
+func runToCqueryOutput(context *Context, pattern string, includeTransitions bool, bazelRelease string) (cqueryOutput, error) {
 	log.Printf("Running cquery on %s", pattern)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -905,15 +1289,31 @@ func runToCqueryResult(context *Context, pattern string, includeTransitions bool
 		args...)
 
 	if returnVal != 0 || err != nil {
-		return nil, fmt.Errorf("failed to run cquery on %s: %w. Stderr:\n%v", pattern, err, stderr.String())
+		return cqueryOutput{}, fmt.Errorf("failed to run cquery on %s: %w. Stderr:\n%v", pattern, err, stderr.String())
 	}
 
-	if useStreamedProto {
+	return cqueryOutput{
+		stdout:           stdout.Bytes(),
+		useStreamedProto: useStreamedProto,
+	}, nil
+}
+
+func parseTransitiveCqueryResult(output cqueryOutput, normalizer *Normalizer) (map[label.Label]map[Configuration]*analysis.ConfiguredTarget, error) {
+	targets, err := parseCqueryOutput(output)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCqueryResult(targets, normalizer)
+}
+
+func parseCqueryOutput(output cqueryOutput) ([]*analysis.ConfiguredTarget, error) {
+	if output.useStreamedProto {
 		var targets []*analysis.ConfiguredTarget
 		unmarshalOpts := protodelim.UnmarshalOptions{MaxSize: -1}
+		stdout := bytes.NewReader(output.stdout)
 		for {
 			var singleTargetResult analysis.CqueryResult
-			if err = unmarshalOpts.UnmarshalFrom(&stdout, &singleTargetResult); err == io.EOF {
+			if err := unmarshalOpts.UnmarshalFrom(stdout, &singleTargetResult); err == io.EOF {
 				break
 			} else if err != nil {
 				return nil, fmt.Errorf("failed to unmarshal streamed cquery stdout: %w", err)
@@ -923,7 +1323,7 @@ func runToCqueryResult(context *Context, pattern string, includeTransitions bool
 		return targets, nil
 	} else {
 		var result analysis.CqueryResult
-		if err = proto.Unmarshal(stdout.Bytes(), &result); err != nil {
+		if err := proto.Unmarshal(output.stdout, &result); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal cquery stdout: %w", err)
 		}
 		return result.GetResults(), nil

--- a/pkg/target_determinator_test.go
+++ b/pkg/target_determinator_test.go
@@ -8,6 +8,11 @@ import (
 	"testing"
 
 	"github.com/bazel-contrib/target-determinator/common"
+	ss "github.com/bazel-contrib/target-determinator/common/sorted_set"
+	"github.com/bazel-contrib/target-determinator/third_party/protobuf/bazel/analysis"
+	"github.com/bazel-contrib/target-determinator/third_party/protobuf/bazel/build"
+	gazelle_label "github.com/bazelbuild/bazel-gazelle/label"
+	"google.golang.org/protobuf/proto"
 )
 
 func Test_stringSliceContainsStartingWith(t *testing.T) {
@@ -166,6 +171,177 @@ func TestGitSafeCheckoutRestoresOriginalAfterPostCheckoutDirtyWorktreeFallback(t
 	if _, err := os.Stat(filepath.Join(repo, "ignored-file")); err != nil {
 		t.Fatalf("ignored file was not preserved in primary checkout: %v", err)
 	}
+}
+
+func TestMetadataAndSourceChangesProveNoAffectedTargets(t *testing.T) {
+	workspace := t.TempDir()
+	matchingTarget := mustParseLabel("//pkg:test")
+	config := NormalizeConfiguration("cfg")
+	sourceFile := "pkg/source.txt"
+	fingerprints := map[string][]byte{
+		"//pkg:test\x00cfg": []byte("same"),
+	}
+
+	for _, tt := range []struct {
+		name              string
+		changedPaths      []string
+		beforeRelease     string
+		afterRelease      string
+		beforeTargets     []gazelle_label.Label
+		afterTargets      []gazelle_label.Label
+		beforeFingerprint []byte
+		afterFingerprint  []byte
+		want              bool
+	}{
+		{
+			name:              "changed file outside transitive source graph",
+			changedPaths:      []string{"README.md"},
+			beforeRelease:     "release 7.0.0",
+			afterRelease:      "release 7.0.0",
+			beforeTargets:     []gazelle_label.Label{matchingTarget},
+			afterTargets:      []gazelle_label.Label{matchingTarget},
+			beforeFingerprint: []byte("same"),
+			afterFingerprint:  []byte("same"),
+			want:              true,
+		},
+		{
+			name:              "changed source file in transitive source graph",
+			changedPaths:      []string{sourceFile},
+			beforeRelease:     "release 7.0.0",
+			afterRelease:      "release 7.0.0",
+			beforeTargets:     []gazelle_label.Label{matchingTarget},
+			afterTargets:      []gazelle_label.Label{matchingTarget},
+			beforeFingerprint: []byte("same"),
+			afterFingerprint:  []byte("same"),
+			want:              false,
+		},
+		{
+			name:              "changed source file parent directory",
+			changedPaths:      []string{"pkg"},
+			beforeRelease:     "release 7.0.0",
+			afterRelease:      "release 7.0.0",
+			beforeTargets:     []gazelle_label.Label{matchingTarget},
+			afterTargets:      []gazelle_label.Label{matchingTarget},
+			beforeFingerprint: []byte("same"),
+			afterFingerprint:  []byte("same"),
+			want:              false,
+		},
+		{
+			name:              "changed build metadata",
+			changedPaths:      []string{"pkg/BUILD.bazel"},
+			beforeRelease:     "release 7.0.0",
+			afterRelease:      "release 7.0.0",
+			beforeTargets:     []gazelle_label.Label{matchingTarget},
+			afterTargets:      []gazelle_label.Label{matchingTarget},
+			beforeFingerprint: []byte("same"),
+			afterFingerprint:  []byte("same"),
+			want:              false,
+		},
+		{
+			name:              "matching targets differ",
+			changedPaths:      []string{"README.md"},
+			beforeRelease:     "release 7.0.0",
+			afterRelease:      "release 7.0.0",
+			beforeTargets:     []gazelle_label.Label{matchingTarget},
+			afterTargets:      []gazelle_label.Label{mustParseLabel("//pkg:other_test")},
+			beforeFingerprint: []byte("same"),
+			afterFingerprint:  []byte("same"),
+			want:              false,
+		},
+		{
+			name:              "semantic metadata differs",
+			changedPaths:      []string{"README.md"},
+			beforeRelease:     "release 7.0.0",
+			afterRelease:      "release 7.0.0",
+			beforeTargets:     []gazelle_label.Label{matchingTarget},
+			afterTargets:      []gazelle_label.Label{matchingTarget},
+			beforeFingerprint: []byte("before"),
+			afterFingerprint:  []byte("after"),
+			want:              false,
+		},
+		{
+			name:              "bazel release differs",
+			changedPaths:      []string{"README.md"},
+			beforeRelease:     "release 7.0.0",
+			afterRelease:      "release 7.1.0",
+			beforeTargets:     []gazelle_label.Label{matchingTarget},
+			afterTargets:      []gazelle_label.Label{matchingTarget},
+			beforeFingerprint: []byte("same"),
+			afterFingerprint:  []byte("same"),
+			want:              false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			beforeFingerprints := copyFingerprintMap(fingerprints)
+			beforeFingerprints["//pkg:test\x00cfg"] = tt.beforeFingerprint
+			afterFingerprints := copyFingerprintMap(fingerprints)
+			afterFingerprints["//pkg:test\x00cfg"] = tt.afterFingerprint
+
+			before := queryResultsForFastPathTest(t, workspace, tt.beforeRelease, tt.beforeTargets, config, sourceFile, beforeFingerprints)
+			after := queryResultsForFastPathTest(t, workspace, tt.afterRelease, tt.afterTargets, config, sourceFile, afterFingerprints)
+
+			got := metadataAndSourceChangesProveNoAffectedTargets(before, after, NewChangedPathSet(tt.changedPaths))
+			if got != tt.want {
+				t.Fatalf("metadataAndSourceChangesProveNoAffectedTargets() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func queryResultsForFastPathTest(
+	t *testing.T,
+	workspace string,
+	bazelRelease string,
+	matchingTargets []gazelle_label.Label,
+	config Configuration,
+	sourceFile string,
+	metadataFingerprints map[string][]byte,
+) *QueryResults {
+	t.Helper()
+
+	n := Normalizer{}
+	targetHashCache := NewTargetHashCache(nil, &n, bazelRelease)
+	targetHashCache.SetWorkspacePath(workspace)
+	targetHashCache.RestoreMetadataFingerprints(metadataFingerprints)
+
+	sourceLabel := mustParseLabel("//pkg:source.txt")
+	return &QueryResults{
+		MatchingTargets: matchingTargetsForTest(matchingTargets, config),
+		TransitiveConfiguredTargets: map[gazelle_label.Label]map[Configuration]*analysis.ConfiguredTarget{
+			sourceLabel: {
+				NormalizeConfiguration(""): {
+					Target: &build.Target{
+						Type: build.Target_SOURCE_FILE.Enum(),
+						SourceFile: &build.SourceFile{
+							Name:     proto.String(sourceLabel.String()),
+							Location: proto.String(filepath.Join(workspace, sourceFile) + ":1:1"),
+						},
+					},
+				},
+			},
+		},
+		TargetHashCache: targetHashCache,
+		BazelRelease:    bazelRelease,
+	}
+}
+
+func matchingTargetsForTest(labels []gazelle_label.Label, config Configuration) *MatchingTargets {
+	labelsToConfigurations := make(map[gazelle_label.Label]*ss.SortedSet[Configuration], len(labels))
+	for _, l := range labels {
+		labelsToConfigurations[l] = ss.NewSortedSetFn([]Configuration{config}, ConfigurationLess)
+	}
+	return &MatchingTargets{
+		labels:                 ss.NewSortedSetFn(labels, CompareLabels),
+		labelsToConfigurations: labelsToConfigurations,
+	}
+}
+
+func copyFingerprintMap(fingerprints map[string][]byte) map[string][]byte {
+	result := make(map[string][]byte, len(fingerprints))
+	for key, value := range fingerprints {
+		result[key] = copyBytes(value)
+	}
+	return result
 }
 
 func runGit(t *testing.T, dir string, args ...string) string {

--- a/pkg/target_determinator_test.go
+++ b/pkg/target_determinator_test.go
@@ -1,6 +1,10 @@
 package pkg
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/bazel-contrib/target-determinator/common"
@@ -97,4 +101,80 @@ func Test_ParseCanonicalLabel(t *testing.T) {
 			t.Errorf("ParseCanonicalLabel() with (label=%s) produces error %s", tt, err)
 		}
 	}
+}
+
+func TestGitSafeCheckoutRestoresOriginalAfterPostCheckoutDirtyWorktreeFallback(t *testing.T) {
+	repo := t.TempDir()
+	runGit(t, repo, "init")
+	runGit(t, repo, "config", "user.name", "Target Determinator Test")
+	runGit(t, repo, "config", "user.email", "target-determinator@example.invalid")
+
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("before\n"), 0644); err != nil {
+		t.Fatalf("failed to write tracked file: %v", err)
+	}
+	runGit(t, repo, "add", "tracked.txt")
+	runGit(t, repo, "commit", "-m", "before")
+	beforeSHA := runGit(t, repo, "rev-parse", "HEAD")
+
+	if err := os.WriteFile(filepath.Join(repo, ".gitignore"), []byte("ignored-file\n"), 0644); err != nil {
+		t.Fatalf("failed to write .gitignore: %v", err)
+	}
+	runGit(t, repo, "add", ".gitignore")
+	runGit(t, repo, "commit", "-m", "after")
+	afterSHA := runGit(t, repo, "rev-parse", "HEAD")
+
+	if err := os.WriteFile(filepath.Join(repo, "ignored-file"), []byte("ignored\n"), 0644); err != nil {
+		t.Fatalf("failed to write ignored file: %v", err)
+	}
+
+	beforeRev, err := NewLabelledGitRev(repo, beforeSHA, "before")
+	if err != nil {
+		t.Fatalf("failed to create before revision: %v", err)
+	}
+	afterRev, err := NewLabelledGitRev(repo, afterSHA, "after")
+	if err != nil {
+		t.Fatalf("failed to create after revision: %v", err)
+	}
+
+	context := &Context{
+		WorkspacePath:        repo,
+		OriginalRevision:     afterRev,
+		CacheDirectory:       t.TempDir(),
+		EnforceCleanRepo:     false,
+		DeleteCachedWorktree: true,
+	}
+
+	worktree, err := gitSafeCheckout(context, beforeRev, nil)
+	if err != nil {
+		t.Fatalf("gitSafeCheckout failed: %v", err)
+	}
+	if worktree == "" {
+		t.Fatal("expected gitSafeCheckout to use a worktree")
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(worktree); err != nil {
+			t.Fatalf("failed to remove worktree: %v", err)
+		}
+	})
+
+	if got := runGit(t, repo, "rev-parse", "HEAD"); got != afterSHA {
+		t.Fatalf("primary checkout HEAD = %s, want %s", got, afterSHA)
+	}
+	if got := runGit(t, worktree, "rev-parse", "HEAD"); got != beforeSHA {
+		t.Fatalf("worktree HEAD = %s, want %s", got, beforeSHA)
+	}
+	if _, err := os.Stat(filepath.Join(repo, "ignored-file")); err != nil {
+		t.Fatalf("ignored file was not preserved in primary checkout: %v", err)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return strings.TrimSpace(string(output))
 }

--- a/pkg/walker.go
+++ b/pkg/walker.go
@@ -36,6 +36,10 @@ func WalkAffectedTargets(context *Context, revBefore LabelledGitRev, targets Tar
 		log.Printf("WARN: Bazel was detected to be a development version - if you're using different development versions at the before and after commits, differences between those versions may not be reflected in this output")
 	}
 
+	if afterMetadata.NoAffectedTargets {
+		return nil
+	}
+
 	for _, l := range afterMetadata.MatchingTargets.Labels() {
 		if err := DiffSingleLabel(beforeMetadata, afterMetadata, includeDifferences, l, callback); err != nil {
 			return err

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BUILD.bazel
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/BUILD.bazel
@@ -46,6 +46,30 @@ java_test(
     ],
 )
 
+java_test(
+    name = "TargetDeterminatorOptimizationIntegrationTest",
+    srcs = [
+        "TargetDeterminatorOptimizationIntegrationTest.java",
+    ],
+    data = ["//target-determinator"],
+    env_inherit = ["CC"],
+    jvm_flags = [
+        "-Dtarget_determinator=$(rootpath //target-determinator)",
+    ],
+    tags = [
+        "manual",
+        "no-sandbox",
+    ],
+    deps = [
+        ":tests",
+        ":util",
+        "//tests/integration/java/com/github/bazel_contrib/target_determinator/label",
+        artifact("junit:junit"),
+        artifact("org.eclipse.jgit:org.eclipse.jgit"),
+        artifact("org.hamcrest:hamcrest-all"),
+    ],
+)
+
 java_library(
     name = "tests",
     srcs = [

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminator.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminator.java
@@ -23,12 +23,35 @@ public class TargetDeterminator {
   /** Get the targets returned by a run of target-determinator. */
   public static Set<Label> getTargets(Path workspace, String... argv)
       throws TargetComputationErrorException {
-    return parseLabels(getOutput(workspace, TARGET_DETERMINATOR, argv));
+    return parseLabels(getResult(workspace, TARGET_DETERMINATOR, argv).stdout());
   }
 
   /** Get the stdout returned by a run of target-determinator. */
   public static String getOutput(Path workingDirectory, String... argv) throws TargetComputationErrorException {
-    return getOutput(workingDirectory, TARGET_DETERMINATOR, argv);
+    return getResult(workingDirectory, TARGET_DETERMINATOR, argv).stdout();
+  }
+
+  /** Get the stdout and stderr returned by a run of target-determinator. */
+  public static Result getResult(Path workingDirectory, String... argv) throws TargetComputationErrorException {
+    return getResult(workingDirectory, TARGET_DETERMINATOR, argv);
+  }
+
+  public static class Result {
+    private final String stdout;
+    private final String stderr;
+
+    private Result(String stdout, String stderr) {
+      this.stdout = stdout;
+      this.stderr = stderr;
+    }
+
+    public String stdout() {
+      return stdout;
+    }
+
+    public String stderr() {
+      return stderr;
+    }
   }
 
   public static Set<Label> parseLabels(String output) {
@@ -47,7 +70,7 @@ public class TargetDeterminator {
     return cacheDir.resolve(String.format("td-worktree-%s-%s", workingDirectory.getFileName(), workingDirHash));
   }
 
-  private static String getOutput(Path workingDirectory, String argv0, String... argv)
+  private static Result getResult(Path workingDirectory, String argv0, String... argv)
       throws TargetComputationErrorException {
     ProcessBuilder processBuilder = new ProcessBuilder(argv0);
     for (String arg : argv) {
@@ -73,7 +96,7 @@ public class TargetDeterminator {
             output,
             stderr);
       }
-      return output;
+      return new Result(output, stderr);
     } catch (IOException | InterruptedException e) {
       throw new RuntimeException(e);
     }

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorOptimizationIntegrationTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorOptimizationIntegrationTest.java
@@ -1,0 +1,86 @@
+package com.github.bazel_contrib.target_determinator.integration;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.util.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+public class TargetDeterminatorOptimizationIntegrationTest {
+  private static TestdataRepo testdataRepo;
+
+  private static Path testDir;
+
+  @BeforeClass
+  public static void cloneRepo() throws Exception {
+    testdataRepo = Util.cloneTestdataRepo();
+    testDir = Files.createTempDirectory("target-determinator-optimization-testdata-clone");
+  }
+
+  @Before
+  public void createTestRepository() throws Exception {
+    testdataRepo.cloneTo(testDir);
+  }
+
+  @After
+  public void cleanupTestRepository() throws Exception {
+    FileUtils.delete(testDir.toFile(), FileUtils.RECURSIVE | FileUtils.SKIP_MISSING);
+  }
+
+  @Test
+  public void optimizedExecutionSkipsHashingWhenOnlyUnusedFileChanged() throws Exception {
+    TestdataRepo.gitCheckout(testDir, Commits.ONE_TEST_BAZEL7_0_0);
+    commitUnusedFile(testDir);
+
+    TargetDeterminator.Result optimized =
+        getResult(testDir, Commits.ONE_TEST_BAZEL7_0_0, "//java/example:ExampleTest");
+
+    Util.assertTargetsMatch(TargetDeterminator.parseLabels(optimized.stdout()), Set.of(), Set.of(), false);
+    assertThat(
+        optimized.stderr(),
+        containsString("Skipping hash prefill: cquery metadata is unchanged and changed files are outside the transitive source graph"));
+  }
+
+  private TargetDeterminator.Result getResult(Path workspace, String commitBefore, String targets)
+      throws Exception {
+    final List<String> args = new ArrayList<>(
+        List.of(
+            "--working-directory",
+            workspace.toString(),
+            "--bazel",
+            "bazelisk",
+            "--targets",
+            targets,
+            "--nocache_results",
+            "--delete-cached-worktree",
+            commitBefore));
+    return TargetDeterminator.getResult(workspace, args.toArray(new String[0]));
+  }
+
+  private void commitUnusedFile(Path workspace) throws Exception {
+    Path unusedFile = workspace.resolve("unused-file-outside-bazel-graph.txt");
+    Files.writeString(unusedFile, "not referenced by any target\n");
+    commitPath(workspace, unusedFile.getFileName().toString(), "Add unused file outside Bazel graph");
+  }
+
+  private void commitPath(Path workspace, String filePattern, String message) throws Exception {
+    try (Git git = Git.open(workspace.toFile())) {
+      git.add().addFilepattern(filePattern).call();
+      git.commit()
+          .setAuthor("Target Determinator Test", "target-determinator@example.invalid")
+          .setCommitter("Target Determinator Test", "target-determinator@example.invalid")
+          .setMessage(message)
+          .call();
+    }
+  }
+}

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.util.FileUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
@@ -203,6 +204,21 @@ public class TargetDeterminatorSpecificFlagsTest {
     Util.assertTargetsMatch(targets, Set.of(), Set.of(), false);
   }
 
+  @Test
+  public void optimizedExecutionMatchesFullHashingBehavior() throws Exception {
+    assertOptimizedMatchesFullHashingAfterLocalCommit(
+        this::commitModifiedExampleTest,
+        "//java/example:ExampleTest",
+        Set.of("//java/example:ExampleTest"),
+        "Hash prefill fast path disabled: changed files intersect transitive source graph");
+
+    assertOptimizedMatchesFullHashingAfterLocalCommit(
+        this::commitUnusedFile,
+        "//java/example:ExampleTest",
+        Set.of(),
+        "Skipping hash prefill: cquery metadata is unchanged and changed files are outside the transitive source graph");
+  }
+
   private Set<Label> getTargets(String commitBefore, String targets) throws Exception {
     return getTargets(commitBefore, targets, false, true);
   }
@@ -218,9 +234,19 @@ public class TargetDeterminatorSpecificFlagsTest {
   }
 
   private String getOutput(String commitBefore, String targets, boolean enforceClean, boolean deleteCachedWorktree, List<String> flags) throws Exception {
+    return getResult(testDir, commitBefore, targets, enforceClean, deleteCachedWorktree, flags).stdout();
+  }
+
+  private TargetDeterminator.Result getResult(
+      Path workspace,
+      String commitBefore,
+      String targets,
+      boolean enforceClean,
+      boolean deleteCachedWorktree,
+      List<String> flags) throws Exception {
     final List<String> args = Stream.concat(
         Stream.of("--working-directory",
-            testDir.toString(),
+            workspace.toString(),
             "--bazel", "bazelisk",
             "--targets", targets,
             "--nocache_results"
@@ -234,6 +260,75 @@ public class TargetDeterminatorSpecificFlagsTest {
       args.add("--delete-cached-worktree");
     }
     args.add(commitBefore);
-    return TargetDeterminator.getOutput(testDir, args.toArray(new String[0]));
+    return TargetDeterminator.getResult(workspace, args.toArray(new String[0]));
+  }
+
+  private void assertOptimizedMatchesFullHashingAfterLocalCommit(
+      WorkspaceChange workspaceChange,
+      String targets,
+      Set<String> expectedTargets,
+      String optimizedPathLog) throws Exception {
+    Path optimizedDir = Files.createTempDirectory("target-determinator-optimized-parity");
+    Path fullHashDir = Files.createTempDirectory("target-determinator-full-hash-parity");
+    try {
+      testdataRepo.cloneTo(optimizedDir);
+      testdataRepo.cloneTo(fullHashDir);
+      TestdataRepo.gitCheckout(optimizedDir, Commits.ONE_TEST_BAZEL7_0_0);
+      TestdataRepo.gitCheckout(fullHashDir, Commits.ONE_TEST_BAZEL7_0_0);
+      workspaceChange.apply(optimizedDir);
+      workspaceChange.apply(fullHashDir);
+      Files.createFile(fullHashDir.resolve("untracked-file"));
+
+      TargetDeterminator.Result optimized =
+          getResult(optimizedDir, Commits.ONE_TEST_BAZEL7_0_0, targets, false, true, List.of());
+      TargetDeterminator.Result fullHash =
+          getResult(fullHashDir, Commits.ONE_TEST_BAZEL7_0_0, targets, false, true, List.of());
+
+      assertResultParity(optimized, fullHash, expectedTargets);
+      assertThat(optimized.stderr(), containsString(optimizedPathLog));
+      assertThat(
+          fullHash.stderr(),
+          containsString("Source file hash reuse disabled: failed to determine changed files"));
+    } finally {
+      FileUtils.delete(optimizedDir.toFile(), FileUtils.RECURSIVE | FileUtils.SKIP_MISSING);
+      FileUtils.delete(fullHashDir.toFile(), FileUtils.RECURSIVE | FileUtils.SKIP_MISSING);
+    }
+  }
+
+  private void assertResultParity(
+      TargetDeterminator.Result optimized,
+      TargetDeterminator.Result fullHash,
+      Set<String> expectedTargets) throws Exception {
+    Set<Label> optimizedTargets = TargetDeterminator.parseLabels(optimized.stdout());
+    Set<Label> fullHashTargets = TargetDeterminator.parseLabels(fullHash.stdout());
+    assertThat(optimizedTargets, equalTo(fullHashTargets));
+    Util.assertTargetsMatch(optimizedTargets, expectedTargets, Set.of(), false);
+  }
+
+  private void commitUnusedFile(Path workspace) throws Exception {
+    Path unusedFile = workspace.resolve("unused-file-outside-bazel-graph.txt");
+    Files.writeString(unusedFile, "not referenced by any target\n");
+    commitPath(workspace, unusedFile.getFileName().toString(), "Add unused file outside Bazel graph");
+  }
+
+  private void commitModifiedExampleTest(Path workspace) throws Exception {
+    Path sourceFile = workspace.resolve("java/example/ExampleTest.java");
+    Files.writeString(sourceFile, Files.readString(sourceFile) + "\n// target-determinator parity test\n");
+    commitPath(workspace, "java/example/ExampleTest.java", "Modify example test source");
+  }
+
+  private void commitPath(Path workspace, String filePattern, String message) throws Exception {
+    try (Git git = Git.open(workspace.toFile())) {
+      git.add().addFilepattern(filePattern).call();
+      git.commit()
+          .setAuthor("Target Determinator Test", "target-determinator@example.invalid")
+          .setCommitter("Target Determinator Test", "target-determinator@example.invalid")
+          .setMessage(message)
+          .call();
+    }
+  }
+
+  private interface WorkspaceChange {
+    void apply(Path workspace) throws Exception;
   }
 }

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/TargetDeterminatorSpecificFlagsTest.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.util.FileUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
@@ -204,21 +203,6 @@ public class TargetDeterminatorSpecificFlagsTest {
     Util.assertTargetsMatch(targets, Set.of(), Set.of(), false);
   }
 
-  @Test
-  public void optimizedExecutionMatchesFullHashingBehavior() throws Exception {
-    assertOptimizedMatchesFullHashingAfterLocalCommit(
-        this::commitModifiedExampleTest,
-        "//java/example:ExampleTest",
-        Set.of("//java/example:ExampleTest"),
-        "Hash prefill fast path disabled: changed files intersect transitive source graph");
-
-    assertOptimizedMatchesFullHashingAfterLocalCommit(
-        this::commitUnusedFile,
-        "//java/example:ExampleTest",
-        Set.of(),
-        "Skipping hash prefill: cquery metadata is unchanged and changed files are outside the transitive source graph");
-  }
-
   private Set<Label> getTargets(String commitBefore, String targets) throws Exception {
     return getTargets(commitBefore, targets, false, true);
   }
@@ -263,72 +247,4 @@ public class TargetDeterminatorSpecificFlagsTest {
     return TargetDeterminator.getResult(workspace, args.toArray(new String[0]));
   }
 
-  private void assertOptimizedMatchesFullHashingAfterLocalCommit(
-      WorkspaceChange workspaceChange,
-      String targets,
-      Set<String> expectedTargets,
-      String optimizedPathLog) throws Exception {
-    Path optimizedDir = Files.createTempDirectory("target-determinator-optimized-parity");
-    Path fullHashDir = Files.createTempDirectory("target-determinator-full-hash-parity");
-    try {
-      testdataRepo.cloneTo(optimizedDir);
-      testdataRepo.cloneTo(fullHashDir);
-      TestdataRepo.gitCheckout(optimizedDir, Commits.ONE_TEST_BAZEL7_0_0);
-      TestdataRepo.gitCheckout(fullHashDir, Commits.ONE_TEST_BAZEL7_0_0);
-      workspaceChange.apply(optimizedDir);
-      workspaceChange.apply(fullHashDir);
-      Files.createFile(fullHashDir.resolve("untracked-file"));
-
-      TargetDeterminator.Result optimized =
-          getResult(optimizedDir, Commits.ONE_TEST_BAZEL7_0_0, targets, false, true, List.of());
-      TargetDeterminator.Result fullHash =
-          getResult(fullHashDir, Commits.ONE_TEST_BAZEL7_0_0, targets, false, true, List.of());
-
-      assertResultParity(optimized, fullHash, expectedTargets);
-      assertThat(optimized.stderr(), containsString(optimizedPathLog));
-      assertThat(
-          fullHash.stderr(),
-          containsString("Source file hash reuse disabled: failed to determine changed files"));
-    } finally {
-      FileUtils.delete(optimizedDir.toFile(), FileUtils.RECURSIVE | FileUtils.SKIP_MISSING);
-      FileUtils.delete(fullHashDir.toFile(), FileUtils.RECURSIVE | FileUtils.SKIP_MISSING);
-    }
-  }
-
-  private void assertResultParity(
-      TargetDeterminator.Result optimized,
-      TargetDeterminator.Result fullHash,
-      Set<String> expectedTargets) throws Exception {
-    Set<Label> optimizedTargets = TargetDeterminator.parseLabels(optimized.stdout());
-    Set<Label> fullHashTargets = TargetDeterminator.parseLabels(fullHash.stdout());
-    assertThat(optimizedTargets, equalTo(fullHashTargets));
-    Util.assertTargetsMatch(optimizedTargets, expectedTargets, Set.of(), false);
-  }
-
-  private void commitUnusedFile(Path workspace) throws Exception {
-    Path unusedFile = workspace.resolve("unused-file-outside-bazel-graph.txt");
-    Files.writeString(unusedFile, "not referenced by any target\n");
-    commitPath(workspace, unusedFile.getFileName().toString(), "Add unused file outside Bazel graph");
-  }
-
-  private void commitModifiedExampleTest(Path workspace) throws Exception {
-    Path sourceFile = workspace.resolve("java/example/ExampleTest.java");
-    Files.writeString(sourceFile, Files.readString(sourceFile) + "\n// target-determinator parity test\n");
-    commitPath(workspace, "java/example/ExampleTest.java", "Modify example test source");
-  }
-
-  private void commitPath(Path workspace, String filePattern, String message) throws Exception {
-    try (Git git = Git.open(workspace.toFile())) {
-      git.add().addFilepattern(filePattern).call();
-      git.commit()
-          .setAuthor("Target Determinator Test", "target-determinator@example.invalid")
-          .setCommitter("Target Determinator Test", "target-determinator@example.invalid")
-          .setMessage(message)
-          .call();
-    }
-  }
-
-  private interface WorkspaceChange {
-    void apply(Path workspace) throws Exception;
-  }
 }


### PR DESCRIPTION
This was achieved with gpt-5.5 on xhigh. I also took https://github.com/bazel-contrib/target-determinator/issues/118 as the start for those changes, and asked the agent to aim for a 50% improvements and scoped down when we realized cquery was taking a big portion of the processing time.


## Summary

  This change improves target-determinator performance while keeping Bazel cquery strategy unchanged as the source of truth.

  Main changes:

  - Overlap before-revision target hashing with after-revision Bazel query work in the existing sequential execution flow.
  - Normalize workspace/output-base-sensitive configuration and attribute data before semantic comparisons.
  - Add a safe fast path that skips after-revision hash prefill only when cquery metadata is unchanged and changed files do not intersect the transitive source graph.
  - Extend TD result-cache metadata to include source-file hashes and semantic metadata fingerprints for future cache-aware optimizations.

### Optimization logging

  This change keeps the optimization logging intentionally low-cardinality. The logs describe which optimization path was selected, or why a fast path was skipped, without logging individual targets, source files, packages, or
  dependency edges.

  The new messages are decision-level only. Successful fast-path cases include messages such as:

  ```text
  Skipping hash prefill: cquery metadata is unchanged and changed files are outside the transitive source graph
  ```

  When an optimization cannot be used, TD logs the reason once for that decision point, for example:

  ```text
  Source file hash reuse disabled: failed to determine changed files: <error>
  Hash prefill fast path disabled: build metadata path changed
  Hash prefill fast path disabled: matching targets differ
  Hash prefill fast path disabled: semantic cquery metadata differs
  Hash prefill fast path disabled: changed files intersect transitive source graph
  ```

  These logs should remain suitable for large repositories because they do not scale with repository size. They are meant to make benchmark and production behavior explainable: whether TD reused cached/source-file hash data, skipped
  unnecessary hash prefill, or fell back to the full hashing path.



  ## Benchmark

  Scenario: Go SDK upgrade from 1.26.2 to 1.26.4. The watermark output from TD v0.34.0 found 7,203 affected targets.

  Machine specs:

  - MacBook Pro Mac16,7
  - Apple M4 Pro, 14 cores: 10 performance + 4 efficiency
  - 48 GB memory
  - macOS 26.5.1, Darwin 25.5.0, arm64
  - Benchmark workspace Bazel: 9.1.1

The benchmark was run against a large Bazel workspace on a Go SDK/toolchain bump from Go SDK 1.26.2 to 1.26.4. This kind of change is intentionally broad because toolchain changes fan out through most Go targets.

This benchmark was executed on go, java, python, rust, CC.

  Relevant Bazel scope:

  | Metric | Count |
  |---|---:|
  | Requested top-level targets in the benchmark scope | 9,876 |
  | Compatible top-level targets after platform filtering | 8,948 |
  | Affected targets reported by TD | 7,203 |
  | Affected share of compatible targets | 80.5% |
  | Affected share of requested top-level targets | 72.9% |
  | Configured dependency nodes explored by transitive `cquery`, per revision | 278,101 |
  | Configured dependency nodes explored across before/after revisions | 556,202 |

Bazel query work is the current lower bound for cold runs. In the instrumented benchmark, explicit Bazel query invocations took `197.3s`, and the practical query-bound floor observed during benchmarking was approximately `229s`.
 
Further large reductions would require changing the Bazel query strategy itself.; TD-only hashing/cache improvements cannot make a cold run faster than the time spent waiting on Bazel queries.

  | Cache state | v0.34.0 | This branch | Result |
  |---|---:|---:|---|
  | No cache, `-nocache_results` | 390.96s | 331.67s | 15.2% faster |
  | Cache enabled, empty cache | 391.56s | 289.37s | 26.1% faster |
  | Both revisions cached | 3.06s | 3.60s | slower, still seconds |
  | Before revision cached only, same checkout path | 214.76s | 184.48s | 14.1% faster |

  Notes:

  - In this SDK-upgrade case, the fast path correctly disabled itself because build metadata changed.
  - A cross-workspace-root cache experiment produced a larger affected set for both versions. Same checkout-path cache restore produced the correct 7,203-target output.
  - Setup/prewarm runs that compare a commit to itself are expected to produce zero affected targets; they were not used as measured SDK-upgrade rows.

  ## Validation

  - bazel test --keep_going //...
  - bazel build //target-determinator:target-determinator
  - Output validity checked by sorted SHA-256 comparison against the v0.34.0 no-cache watermark.
