### PR TITLE
Add composite GitHub Action wrapping release binaries

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,0 +1,95 @@
+name: test-action
+on:
+  pull_request:
+    paths:
+      - 'action.yml'
+      - '.github/workflows/test-action.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'action.yml'
+      - '.github/workflows/test-action.yml'
+
+jobs:
+  self-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build a minimal fixture workspace with a real before/after commit
+        id: fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+          fixture="$RUNNER_TEMP/td-action-fixture"
+          rm -rf "$fixture"
+          mkdir -p "$fixture"
+          cd "$fixture"
+          git init -q
+          git config user.email "test@example.com"
+          git config user.name "test"
+
+          cat > MODULE.bazel <<'EOF'
+          module(name = "td_action_test")
+          EOF
+
+          mkdir -p pkg_a pkg_b
+          cat > pkg_a/BUILD.bazel <<'EOF'
+          genrule(
+              name = "gen_a",
+              srcs = ["input.txt"],
+              outs = ["output.txt"],
+              cmd = "cp $< $@",
+          )
+          EOF
+          echo "v1" > pkg_a/input.txt
+
+          cat > pkg_b/BUILD.bazel <<'EOF'
+          genrule(
+              name = "gen_b",
+              srcs = ["input.txt"],
+              outs = ["output.txt"],
+              cmd = "cp $< $@",
+          )
+          EOF
+          echo "unrelated" > pkg_b/input.txt
+
+          git add -A
+          git commit -q -m "before"
+          before_sha=$(git rev-parse HEAD)
+
+          echo "v2" > pkg_a/input.txt
+          git add -A
+          git commit -q -m "after"
+
+          echo "fixture-dir=$fixture" >> "$GITHUB_OUTPUT"
+          echo "before-sha=$before_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Run target-determinator action against the fixture
+        id: td
+        uses: ./
+        with:
+          before-revision: ${{ steps.fixture.outputs.before-sha }}
+          working-directory: ${{ steps.fixture.outputs.fixture-dir }}
+          targets: '//...'
+
+      - name: Assert only the changed package's target is reported
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Affected targets:"
+          echo "${{ steps.td.outputs.affected-targets }}"
+
+          if [ "${{ steps.td.outputs.count }}" != "1" ]; then
+            echo "Expected exactly 1 affected target, got ${{ steps.td.outputs.count }}" >&2
+            exit 1
+          fi
+          case "${{ steps.td.outputs.affected-targets }}" in
+            *"//pkg_a:gen_a"*) ;;
+            *) echo "Expected //pkg_a:gen_a to be reported as affected" >&2; exit 1 ;;
+          esac
+          case "${{ steps.td.outputs.affected-targets }}" in
+            *"//pkg_b:gen_b"*) echo "//pkg_b:gen_b should NOT be affected (unrelated package)" >&2; exit 1 ;;
+            *) ;;
+          esac
+          echo "OK: action correctly isolated the changed package."

--- a/README.md
+++ b/README.md
@@ -116,6 +116,26 @@ With caching, however, the "before" result may have been computed in an earlier 
 
 In practice this matters most in release pipelines where stamping or versioning variables (e.g. `MY_PKG_VERSION`) change between runs. If you want to answer "which targets would have changed, assuming the environment is the same before and after?", run `target-determinator` with `--nocache_results` to force both computations to happen in the same environment.
 
+## GitHub Action
+
+A composite GitHub Action wraps the pre-built release binaries, so you can use Target Determinator in a workflow without managing the binary download yourself:
+
+```yaml
+- uses: bazel-contrib/target-determinator@main
+  id: td
+  with:
+    targets: '//...'          # optional, defaults to //...
+    before-revision: ''       # optional, defaults to the PR base SHA
+    working-directory: '.'    # optional
+    bazel: 'bazel'            # optional
+    version: 'latest'         # optional, pin to a specific release e.g. v0.34.0
+
+- run: echo "Affected ${{ steps.td.outputs.count }} targets"
+- run: echo "${{ steps.td.outputs.affected-targets }}"
+```
+
+The action also writes a summary of the affected targets to the workflow's job summary.
+
 ## How to get Target Determinator
 
 Pre-built binary releases are published as [GitHub Releases](https://github.com/bazel-contrib/target-determinator/releases) for most changes.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,111 @@
+name: 'Target Determinator'
+description: 'Determines which Bazel targets are affected between two git revisions, using pre-built target-determinator release binaries.'
+author: 'bazel-contrib'
+
+inputs:
+  before-revision:
+    description: 'Git revision to diff against. Defaults to the pull request base SHA, or the previous commit on push.'
+    required: false
+    default: ''
+  targets:
+    description: 'Bazel query expression scoping which targets to consider.'
+    required: false
+    default: '//...'
+  working-directory:
+    description: 'Working directory containing the Bazel workspace to query.'
+    required: false
+    default: '.'
+  bazel:
+    description: 'Bazel binary (on PATH, or absolute/relative path) to run.'
+    required: false
+    default: 'bazel'
+  version:
+    description: 'target-determinator release version to use (e.g. v0.34.0). Defaults to the latest release.'
+    required: false
+    default: 'latest'
+
+outputs:
+  affected-targets:
+    description: 'Newline-separated list of affected Bazel target labels.'
+    value: ${{ steps.run.outputs.affected-targets }}
+  count:
+    description: 'Number of affected targets.'
+    value: ${{ steps.run.outputs.count }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve before-revision
+      id: resolve-revision
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.before-revision }}" ]; then
+          echo "revision=${{ inputs.before-revision }}" >> "$GITHUB_OUTPUT"
+        elif [ -n "${{ github.event.pull_request.base.sha }}" ]; then
+          echo "revision=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "revision=HEAD~1" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Resolve release version
+      id: resolve-version
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        if [ "${{ inputs.version }}" = "latest" ]; then
+          version=$(gh release view --repo bazel-contrib/target-determinator --json tagName --jq .tagName)
+        else
+          version="${{ inputs.version }}"
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    - name: Download target-determinator binary
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+        arch="$(uname -m)"
+        case "$arch" in
+          x86_64) arch="amd64" ;;
+          arm64|aarch64) arch="arm64" ;;
+          *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
+        esac
+        asset="target-determinator.${os}.${arch}"
+        gh release download "${{ steps.resolve-version.outputs.version }}" \
+          --repo bazel-contrib/target-determinator \
+          --pattern "$asset" \
+          --output "$RUNNER_TEMP/target-determinator" \
+          --clobber
+        chmod +x "$RUNNER_TEMP/target-determinator"
+
+    - name: Run target-determinator
+      id: run
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+        affected="$("$RUNNER_TEMP/target-determinator" \
+          -targets "${{ inputs.targets }}" \
+          -bazel "${{ inputs.bazel }}" \
+          -working-directory . \
+          "${{ steps.resolve-revision.outputs.revision }}")"
+
+        {
+          echo "affected-targets<<TD_EOF"
+          echo "$affected"
+          echo "TD_EOF"
+        } >> "$GITHUB_OUTPUT"
+
+        count=$(printf '%s\n' "$affected" | grep -c . || true)
+        echo "count=$count" >> "$GITHUB_OUTPUT"
+
+        {
+          echo "## Target Determinator"
+          echo "**$count** target(s) affected since \`${{ steps.resolve-revision.outputs.revision }}\`"
+          echo '```'
+          printf '%s\n' "$affected"
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Closes #131.

Adds a composite GitHub Action (`action.yml` at repo root) that wraps the pre-built release binaries, so users can run Target Determinator in a workflow without managing the binary download themselves:

```yaml
- uses: bazel-contrib/target-determinator@main
  id: td
  with:
    targets: '//...'          # optional, defaults to //...
    before-revision: ''       # optional, defaults to the PR base SHA
    working-directory: '.'    # optional
    bazel: 'bazel'            # optional
    version: 'latest'         # optional, pin to a specific release e.g. v0.34.0

- run: echo "Affected ${{ steps.td.outputs.count }} targets"
- run: echo "${{ steps.td.outputs.affected-targets }}"
```

It downloads the correct release binary for the runner's OS/arch, runs it against the resolved before-revision (PR base SHA by default), and exposes `affected-targets` and `count` as step outputs, plus a job-summary writeup.

## Testing

Since this repo's existing integration tests are Go/Bazel-based and don't cover composite Action YAML directly, I added `.github/workflows/test-action.yml`, which builds a minimal two-package Bazel fixture with a real before/after commit and asserts the action correctly isolates the changed package's target from an unrelated one. It's been run and passes: https://github.com/suhalvemu/target-determinator/actions/runs/31376161283

I also verified the underlying mechanism manually against a real `v0.34.0` release binary before writing the test, to confirm stdout only contains the clean label list (log output goes to stderr) and that latest-release/OS-arch resolution both work as expected.

I also dogfooded this on a real public repo (a personal multi-language Bazel monorepo), which correctly reported the real affected targets on a real PR: https://github.com/suhalvemu/bazel-monorepo-reference/pull/1

Happy to adjust the input/output surface if you'd prefer a different shape.